### PR TITLE
Removing a mention of 3.11.1

### DIFF
--- a/content/dl.md
+++ b/content/dl.md
@@ -15,10 +15,6 @@ Our latest release (3.11.2) for Windows:
 * [DB Browser for SQLite - .zip (no installer) for 32-bit Windows & Windows XP](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.2-win32.zip)
 * [DB Browser for SQLite - Standard installer for 64-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.2-win64.msi)
 * [DB Browser for SQLite - .zip (no installer) for 64-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.2-win64.zip)
-* Note - There's no PortableApp version for 3.11.1 (yet).  It'll hopefully be ready in a few days.
-
-PortableApp:
-
 * [DB Browser for SQLite - PortableApp](https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe)
 
 **Note** - If for any reason the standard Windows release does not work


### PR DESCRIPTION
There's a PortableApp build of 3.11.2, so no need to mention that there is not such a build of 3.11.1.