### PR TITLE
Update brew install syntax

### DIFF
--- a/content/dl.md
+++ b/content/dl.md
@@ -40,7 +40,7 @@ Our latest release (3.12.1) for macOS:
 
 If you prefer using Homebrew for macOS, our latest release can be installed via [Homebrew Cask](https://caskroom.github.io/ "Homebrew Cask"):
 
-    brew cask install db-browser-for-sqlite
+    brew install --cask db-browser-for-sqlite
 
 ## Nightly builds
 

--- a/docs/dl/index.html
+++ b/docs/dl/index.html
@@ -98,7 +98,7 @@
 </ul>
 <h3 id="homebrew">Homebrew</h3>
 <p>If you prefer using Homebrew for macOS, our latest release can be installed via <a href="https://caskroom.github.io/" title="Homebrew Cask">Homebrew Cask</a>:</p>
-<pre><code>brew cask install db-browser-for-sqlite
+<pre><code>brew install --cask db-browser-for-sqlite
 </code></pre>
 <h2 id="nightly-builds">Nightly builds</h2>
 <p>Download nightly builds for Windows and macOS here:</p>


### PR DESCRIPTION
the correct one for now is 

`cask install --cask`