### PR TITLE
Fully qualify RSS URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,6 +41,7 @@ publishDir = "docs"
 
 [params]
     description = "The Official home of the DB Browser for SQLite."
+    canonicalUrl = "https://sqlitebrowser.org"
 
     # options for highlight.js (version, additional languages, and theme)
     highlightjsVersion = "9.12.0"

--- a/themes/hugo-lithium/layouts/partials/footer.html
+++ b/themes/hugo-lithium/layouts/partials/footer.html
@@ -1,8 +1,8 @@
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="{{ .Site.RSSLink | relURL }}" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="{{.Site.Params.canonicalUrl}}{{ if (.OutputFormats.Get "RSS") }}{{ (.OutputFormats.Get "RSS").RelPermalink }}{{ else }}/index.xml{{ end }}" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/themes/hugo-lithium/layouts/partials/head.html
+++ b/themes/hugo-lithium/layouts/partials/head.html
@@ -26,9 +26,8 @@
 <meta property="keywords" content ="{{ delimit .Keywords ", " }}">
 {{ end }}
 
-{{ with .OutputFormats.Get "RSS" }}
-<link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-{{ end }}
+<link href="{{.Site.Params.canonicalUrl}}{{ if (.OutputFormats.Get "RSS") }}{{ (.OutputFormats.Get "RSS").RelPermalink }}{{ else }}/index.xml{{ end }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+
 {{ partial "head_highlightjs" . }}
 <link rel="stylesheet" href="{{ "css/fonts.css" | relURL }}" media="all">
 


### PR DESCRIPTION
Change RSS url from /index.xml to https://sqlitebrowser.org/ globally. Resolves issue #9.
