### PR TITLE
Hugo exported HTML with the RSS path fix in place

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>About - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -139,9 +140,9 @@ avoid confusion with an existing application called &ldquo;Database Browser&rdqu
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/added-64-bit-windows-development-instructions-to-the-wiki/index.html
+++ b/docs/blog/added-64-bit-windows-development-instructions-to-the-wiki/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Added 64-bit Windows development instructions to the wiki - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/added-public-web-stats-using-fathom/index.html
+++ b/docs/blog/added-public-web-stats-using-fathom/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Added public web stats using Fathom - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -77,7 +78,7 @@
 <p>The setup was fairly easy, though the ARM64 download for the current release (1.2.1) <a href="https://github.com/usefathom/fathom/issues/218">doesn&rsquo;t seem to work with SQLite</a> due to an accidental setting during their build.  Hopefully fixed for the next release.</p>
 <p>PostgreSQL is being the database, and Nginx providing HTTPS termination.</p>
 <p>The <a href="https://stats.sqlitebrowser.org">stats server is public</a>, so added a link to it from our menu bar just because.</p>
-<p>It&rsquo;ll be interesting to see how the stats evolve over time. 😄</p>
+<p>It&rsquo;ll be interesting to see how the stats evolve over time. &#x1f604;</p>
 
     </div>
   </article>
@@ -89,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/adding-basic-visualisation-capability-to-dbhub-io/index.html
+++ b/docs/blog/adding-basic-visualisation-capability-to-dbhub-io/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Adding basic visualisation capability to dbhub.io - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -83,7 +84,7 @@
 <p>Advanced users will ideally be able to input their own SQL queries for generating the data points to visualise.  That&rsquo;s going to take some time however.</p>
 <p>When it&rsquo;s working well, this should for displaying useful visual &ldquo;diffs&rdquo; (aka comparisons) between different revisions of data.  Super useful for all kinds of things, including the still-in-development &ldquo;Merge Request&rdquo; functionality.</p>
 <p><strong><a href="https://dbhub.io/vis/justinclift/Marine%20Litter%20Survey%20%28Keep%20Northern%20Ireland%20Beautiful%29.sqlite">Try it out here</a></strong>.</p>
-<p><a href="https://github.com/sqlitebrowser/dbhub.io/issues">Problem reports</a>, <a href="https://github.com/sqlitebrowser/dbhub.io/issues">feature requests</a>, (etc) are welcome. 😄</p>
+<p><a href="https://github.com/sqlitebrowser/dbhub.io/issues">Problem reports</a>, <a href="https://github.com/sqlitebrowser/dbhub.io/issues">feature requests</a>, (etc) are welcome. &#x1f604;</p>
 
     </div>
   </article>
@@ -95,9 +96,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/appimage-builds-for-linux/index.html
+++ b/docs/blog/appimage-builds-for-linux/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>AppImage builds for Linux - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/apple-silicon-macos-package-available/index.html
+++ b/docs/blog/apple-silicon-macos-package-available/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Apple Silicon (M1/M2/etc) macOS package available - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -98,7 +99,7 @@ based download.</p>
 <li><a href="https://nightlies.sqlitebrowser.org/latest/DB.Browser.for.SQLite-sqlcipher-intel.dmg">DB.Browser.for.SQLite-sqlcipher-intel.dmg</a></li>
 </ul>
 <p>This is thanks to our <a href="https://nightlies.sqlitebrowser.org/latest/DB.Browser.for.SQLite-sqlcipher-intel.dmg">Patreon supporters</a> (for the M1 Mac Mini), and our many Community members providing insight,
-instructions, and all around assistance getting things working on Apple Silicon. 😄</p>
+instructions, and all around assistance getting things working on Apple Silicon. &#x1f604;</p>
 
     </div>
   </article>
@@ -110,9 +111,9 @@ instructions, and all around assistance getting things working on Apple Silicon.
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/comments-now-enabled-on-blog-posts/index.html
+++ b/docs/blog/comments-now-enabled-on-blog-posts/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Comments now enabled on blog posts - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -87,9 +88,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/dark-theme-support-in-our-nightly-builds/index.html
+++ b/docs/blog/dark-theme-support-in-our-nightly-builds/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Dark theme support in our nightly builds - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +95,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/database-sharing-has-been-improved-on-dbhub-io/index.html
+++ b/docs/blog/database-sharing-has-been-improved-on-dbhub-io/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Database sharing has been improved on DBHub.io - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -99,9 +100,9 @@ Click the blue &lsquo;Save&rsquo; button to save your changes.  You&rsquo;ll ret
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/execute-sql-tab-overhaul/index.html
+++ b/docs/blog/execute-sql-tab-overhaul/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Execute SQL Tab Overhaul - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -95,9 +96,9 @@ It has syntax-highlighting support so field names are more easily identifiable c
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-alpha-release-for-3-11-0/index.html
+++ b/docs/blog/first-alpha-release-for-3-11-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First alpha release for 3.11.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-alpha-release-for-3-12-0/index.html
+++ b/docs/blog/first-alpha-release-for-3-12-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First alpha release for 3.12.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -186,7 +187,7 @@
 <p>We have added proxy support to our network code. So it is finally possible to use DB4S through a proxy, for example, your company proxy. This also changes the defaults to use the system proxy configuration instead of not using any proxy at all.</p>
 </li>
 <li>
-<p>The proxy settings affect all network code. This includes the automatic update check on Windows and macOS but also the <a href="https://dbhub.io">dbhub.io</a> integration. If you have not heard of it before, dbhub.io is a cloud service which allows you to work on SQLite databases collaboratively. It is developed by the same developers as DB4S. You can check it out for free. 😄</p>
+<p>The proxy settings affect all network code. This includes the automatic update check on Windows and macOS but also the <a href="https://dbhub.io">dbhub.io</a> integration. If you have not heard of it before, dbhub.io is a cloud service which allows you to work on SQLite databases collaboratively. It is developed by the same developers as DB4S. You can check it out for free. &#x1f604;</p>
 </li>
 <li>
 <p>To change the proxy settings, open the Preferences dialog, go to the Remote tab, and click on the Configure button in the proxy section.
@@ -372,9 +373,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/index.html
+++ b/docs/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First (beta) DBHub.io server with DB4S integration is online - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -74,7 +75,7 @@
 
     <div class="article-content">
       <p>The first &ldquo;<a href="https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite">db4s-beta</a>&rdquo; server is now online, which DB4S 3.10.0-beta can store/retrieve databases in.</p>
-<center>Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). 😄
+<center>Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). :smile:
 <p>Don&rsquo;t store important data in it yet though, as we don&rsquo;t have backups set up yet.</center></p>
 
     </div>
@@ -87,9 +88,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-beta-release-of-3-10-0/index.html
+++ b/docs/blog/first-beta-release-of-3-10-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First beta release of 3.10.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-beta-release-of-3-11-0/index.html
+++ b/docs/blog/first-beta-release-of-3-11-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First beta release of 3.11.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-release-candidate-for-3-12-0/index.html
+++ b/docs/blog/first-release-candidate-for-3-12-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First release candidate for 3.12.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -144,9 +145,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-release-candidate-for-3-12-1/index.html
+++ b/docs/blog/first-release-candidate-for-3-12-1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First release candidate for 3.12.1 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>This is the first, and hopefully only 😉, release candidate for DB Browser for SQLite version 3.12.1.</p>
+      <p>This is the first, and hopefully only &#x1f609;, release candidate for DB Browser for SQLite version 3.12.1.</p>
 <h2 id="downloads">Downloads</h2>
 <ul>
 <li><a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.1-rc1/DB.Browser.for.SQLite-3.12.1-rc1-win32.msi">DB.Browser.for.SQLite-3.12.1-rc1-win32.msi</a> - Standard installer for 32-bit Windows</li>
@@ -172,9 +173,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-release-pydbhub/index.html
+++ b/docs/blog/first-release-pydbhub/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>First release of Python library &#39;pydbhub&#39; - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -75,7 +76,7 @@
     <div class="article-content">
       <p>Thanks to the excellent effort of <a href="https://github.com/LeMoussel">@LeMoussel</a>,
 there is now a Python library for people to use and access their SQLite databases
-on DBHub.io. 😄</p>
+on DBHub.io. &#x1f604;</p>
 <p>It&rsquo;s called <a href="https://github.com/LeMoussel">pydbhub</a>, and is available here:</p>
 <p><a href="https://github.com/LeMoussel/pydbhub">https://github.com/LeMoussel/pydbhub</a></p>
 <p>And on PyPi:</p>
@@ -91,9 +92,9 @@ on DBHub.io. 😄</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/fixed-the-downloads-for-v3-8-0/index.html
+++ b/docs/blog/fixed-the-downloads-for-v3-8-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Fixed the downloads for v3.8.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/fixed-windows-installer-for-3-6-0/index.html
+++ b/docs/blog/fixed-windows-installer-for-3-6-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Fixed windows installer for 3.6.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/go-library-updated-to-work-with-live-databases/index.html
+++ b/docs/blog/go-library-updated-to-work-with-live-databases/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Go Library (go-dbhub) updated to work with Live databases - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/index.html
+++ b/docs/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Thanks to our Patreon supporters, we have a HiDPI monitor! - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -76,7 +77,7 @@
       <p>Thanks to <a href="https://www.patreon.com/db4s">our wonderful Patrons</a>, we&rsquo;ve been able to purchase a HiDPI monitor (<a href="https://www.dell.com/en-uk/shop/cty/dell-24-ultra-hd-4k-monitor-p2415q/spd/dell-p2415q-monitor">Dell P2415Q</a>) for Martin, one of our senior developers.</p>
 <p>A special thanks also goes to Nikolay Zlatev of <a href="http://www.astrapaging.com">Astra Paging</a> too, for organising the purchase and shipping of the monitor around the EU.</p>
 <p>This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</p>
-<p>Good stuff! 😀</p>
+<p>Good stuff! &#x1f600;</p>
 
     </div>
   </article>
@@ -88,9 +89,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/huge-thanks-to-digitalocean/index.html
+++ b/docs/blog/huge-thanks-to-digitalocean/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Huge thanks to DigitalOcean for sponsoring us! - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -74,13 +75,13 @@
 
     <div class="article-content">
       <p>A huge shout out and thanks to <a href="https://www.digitalocean.com">DigitalOcean</a>
-for hosting our entire Infrastructure, 100% free! 🕺</p>
+for hosting our entire Infrastructure, 100% free! &#x1f57a;</p>
 <p>We&rsquo;ve been with them for over a year now, and have a bunch of servers.  In
 that time, we&rsquo;ve experienced <em>no</em> outages or weirdness whatsoever.  It&rsquo;s been
 fantastic!</p>
 <p>If you&rsquo;re looking for a good, reliable Cloud service that doesn&rsquo;t suffer
 from network weirdness or outages, <a href="https://www.digitalocean.com">DigitalOcean</a>
-is a solid choice. 😄</p>
+is a solid choice. &#x1f604;</p>
 
     </div>
   </article>
@@ -92,9 +93,9 @@ is a solid choice. 😄</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Blogs - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/blog/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/blog/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -706,9 +705,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/blog/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -6,865 +6,609 @@
     <description>Recent content in Blogs on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate><atom:link href="/blog/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/blog/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Support for SQLite extensions added</title>
       <link>/blog/support-for-sqlite-extensions-added/</link>
       <pubDate>Thu, 04 May 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/support-for-sqlite-extensions-added/</guid>
-      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:
-FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
+      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:&#xA;FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
     </item>
-    
     <item>
       <title>Live databases can be public .. and more updates</title>
       <link>/blog/live-databases-can-be-public/</link>
       <pubDate>Thu, 27 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-can-be-public/</guid>
-      <description>Another week, and another series of exciting updates to DBHub.io
-Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.
-Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.
-Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
+      <description>Another week, and another series of exciting updates to DBHub.io&#xA;Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.&#xA;Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.&#xA;Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
     </item>
-    
     <item>
       <title>Execute SQL Tab Overhaul</title>
       <link>/blog/execute-sql-tab-overhaul/</link>
       <pubDate>Wed, 26 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/execute-sql-tab-overhaul/</guid>
-      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.
-While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.
-&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;
-It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
+      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.&#xA;While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.&#xA;&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;&#xA;It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
     </item>
-    
     <item>
       <title>Comments now enabled on blog posts</title>
       <link>/blog/comments-now-enabled-on-blog-posts/</link>
       <pubDate>Mon, 24 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/comments-now-enabled-on-blog-posts/</guid>
-      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.
-We look forward to hearing from you!</description>
+      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.&#xA;We look forward to hearing from you!</description>
     </item>
-    
     <item>
       <title>More webUI related updates</title>
       <link>/blog/more-webui-related-updates/</link>
       <pubDate>Fri, 07 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/more-webui-related-updates/</guid>
-      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.
-Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data
-Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
+      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.&#xA;Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data&#xA;Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
     </item>
-    
     <item>
       <title>Database sharing has been improved on DBHub.io</title>
       <link>/blog/database-sharing-has-been-improved-on-dbhub-io/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/database-sharing-has-been-improved-on-dbhub-io/</guid>
-      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.
-DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
+      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.&#xA;DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
     </item>
-    
     <item>
       <title>Go Library (go-dbhub) updated to work with Live databases</title>
       <link>/blog/go-library-updated-to-work-with-live-databases/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/go-library-updated-to-work-with-live-databases/</guid>
-      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.
-You can see the initial blog post for the Go library here .</description>
+      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.&#xA;You can see the initial blog post for the Go library here .</description>
     </item>
-    
     <item>
       <title>Live databases are now .. live!</title>
       <link>/blog/live-databases-are-now-live/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-are-now-live/</guid>
-      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.
-One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
+      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.&#xA;One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
     </item>
-    
     <item>
       <title>Apple Silicon (M1/M2/etc) macOS package available</title>
       <link>/blog/apple-silicon-macos-package-available/</link>
       <pubDate>Mon, 24 Oct 2022 00:00:00 +0000</pubDate>
-      
       <guid>/blog/apple-silicon-macos-package-available/</guid>
-      <description>We are proud to present&amp;hellip; the Apple Silicon (arm64) version of DB Browser for SQLite v3.12.2:
-https://download.sqlitebrowser.org/DB.Browser.for.SQLite-arm64-3.12.2.dmg 0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8 (SHA256 checksum) If you&amp;rsquo;re using one of Apple&amp;rsquo;s M1 or M2 based macOS devices, then this native Apple Silicon version of DB4S should work a bit better than our existing Intel based download.
-Additionally, our nightly builds for macOS now have both Intel and Apple Silicon (arm64) downloads available:
-Nightly builds using SQLite (no encryption):</description>
+      <description>We are proud to present&amp;hellip; the Apple Silicon (arm64) version of DB Browser for SQLite v3.12.2:&#xA;https://download.sqlitebrowser.org/DB.Browser.for.SQLite-arm64-3.12.2.dmg 0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8 (SHA256 checksum) If you&amp;rsquo;re using one of Apple&amp;rsquo;s M1 or M2 based macOS devices, then this native Apple Silicon version of DB4S should work a bit better than our existing Intel based download.&#xA;Additionally, our nightly builds for macOS now have both Intel and Apple Silicon (arm64) downloads available:&#xA;Nightly builds using SQLite (no encryption):</description>
     </item>
-    
     <item>
       <title>Huge thanks to DigitalOcean for sponsoring us!</title>
       <link>/blog/huge-thanks-to-digitalocean/</link>
       <pubDate>Sun, 25 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/huge-thanks-to-digitalocean/</guid>
-      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! 🕺
-We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!
-If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. 😄</description>
+      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! &amp;#x1f57a;&#xA;We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!&#xA;If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Linux AppImage of 3.12.2 release available</title>
       <link>/blog/linux-appimage-available/</link>
       <pubDate>Sat, 10 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/linux-appimage-available/</guid>
-      <description>Thanks to new team member Nikolay Zlatev, an AppImage of our recent 3.12.2 release is available:
-https://download.sqlitebrowser.org/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage ea14c7439f7e666f3e9d8cbffe9048134b87db3e2d7bf65f4146b0649536de5c (SHA256 checksum) That should work on most Linux (x86_64) distributions, and should help people running older software to use our new releases.
-Good stuff Nikolay! 😀</description>
+      <description>Thanks to new team member Nikolay Zlatev, an AppImage of our recent 3.12.2 release is available:&#xA;https://download.sqlitebrowser.org/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage ea14c7439f7e666f3e9d8cbffe9048134b87db3e2d7bf65f4146b0649536de5c (SHA256 checksum) That should work on most Linux (x86_64) distributions, and should help people running older software to use our new releases.&#xA;Good stuff Nikolay! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>First release of Python library &#39;pydbhub&#39;</title>
       <link>/blog/first-release-pydbhub/</link>
       <pubDate>Sat, 05 Jun 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-pydbhub/</guid>
-      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. 😄
-It&amp;rsquo;s called pydbhub, and is available here:
-https://github.com/LeMoussel/pydbhub
-And on PyPi:
-https://pypi.org/project/pydbhub/</description>
+      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. &amp;#x1f604;&#xA;It&amp;rsquo;s called pydbhub, and is available here:&#xA;https://github.com/LeMoussel/pydbhub&#xA;And on PyPi:&#xA;https://pypi.org/project/pydbhub/</description>
     </item>
-    
     <item>
       <title>Version 3.12.2 released</title>
       <link>/blog/version-3-12-2-released/</link>
       <pubDate>Tue, 18 May 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-2-released/</guid>
-      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.
-You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. 😄
-The changes in this over the 3.12.1 release include:
-Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
+      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.&#xA;You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. &amp;#x1f604;&#xA;The changes in this over the 3.12.1 release include:&#xA;Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
     </item>
-    
     <item>
       <title>Thanks to our Patreon supporters, we have a HiDPI monitor!</title>
       <link>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</link>
       <pubDate>Sat, 06 Mar 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</guid>
-      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.
-A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.
-This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
+      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.&#xA;A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.&#xA;This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
     </item>
-    
     <item>
       <title>Version 3.12.1 released</title>
       <link>/blog/version-3-12-1-released/</link>
       <pubDate>Mon, 09 Nov 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-1-released/</guid>
-      <description>This is the first bug fix release for our 3.12.x series.
-There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. 😄
-Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
+      <description>This is the first bug fix release for our 3.12.x series.&#xA;There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. &amp;#x1f604;&#xA;Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.1</title>
       <link>/blog/first-release-candidate-for-3-12-1/</link>
       <pubDate>Sun, 27 Sep 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-1/</guid>
-      <description>This is the first, and hopefully only 😉, release candidate for DB Browser for SQLite version 3.12.1.
-Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:
-Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
+      <description>This is the first, and hopefully only &amp;#x1f609;, release candidate for DB Browser for SQLite version 3.12.1.&#xA;Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:&#xA;Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
     </item>
-    
     <item>
       <title>New Go library for working with your DBHub.io databases</title>
       <link>/blog/new-go-library-for-working-with-your-dbhub-io-databases/</link>
       <pubDate>Sat, 01 Aug 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-go-library-for-working-with-your-dbhub-io-databases/</guid>
-      <description>For anyone with an interest in Go programming, there&amp;rsquo;s now a library to access and query your databases on DBHub.io:
-https://github.com/sqlitebrowser/go-dbhub
-Documentation is in place, code quality is good, and there are worked examples for each function call.
-It&amp;rsquo;s still in early stages of development, but seems to work well already. 😄
-What works now Run read-only queries (eg SELECT statements) on databases, returning the results as JSON List the tables, views, and indexes present in a database List the columns in a table, view or index, along with their details (Added 2020-08-02) - Generate a diff between two databases or revisions, to transform one into the other (Added 2020-08-04) - List the branches of a database (Added 2020-08-04) - Download a complete database (Added 2020-08-05) - List the databases in your account (Added 2020-08-05) - Download the database metadata (branches, releases, tags, commits, etc) Still to do Tests for each function Upload a complete database Investigate what would be needed for this to work through the Go SQL API Anything else that people suggest and seems like a good idea 😄 Requirements Go version 1.</description>
+      <description>For anyone with an interest in Go programming, there&amp;rsquo;s now a library to access and query your databases on DBHub.io:&#xA;https://github.com/sqlitebrowser/go-dbhub&#xA;Documentation is in place, code quality is good, and there are worked examples for each function call.&#xA;It&amp;rsquo;s still in early stages of development, but seems to work well already. &amp;#x1f604;&#xA;What works now Run read-only queries (eg SELECT statements) on databases, returning the results as JSON List the tables, views, and indexes present in a database List the columns in a table, view or index, along with their details (Added 2020-08-02) - Generate a diff between two databases or revisions, to transform one into the other (Added 2020-08-04) - List the branches of a database (Added 2020-08-04) - Download a complete database (Added 2020-08-05) - List the databases in your account (Added 2020-08-05) - Download the database metadata (branches, releases, tags, commits, etc) Still to do Tests for each function Upload a complete database Investigate what would be needed for this to work through the Go SQL API Anything else that people suggest and seems like a good idea &amp;#x1f604; Requirements Go version 1.</description>
     </item>
-    
     <item>
       <title>New API for remotely executing SQLite queries</title>
       <link>/blog/new-api-for-remotely-executing-sqlite-queries/</link>
       <pubDate>Sun, 19 Jul 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-api-for-remotely-executing-sqlite-queries/</guid>
-      <description>For anyone wanting to run SQL queries against their uploaded databases, there&amp;rsquo;s now an API server: https://api.dbhub.io
-As a starting point, there&amp;rsquo;s just one API call (/v1/query), and it only runs SELECT queries (eg read only database). That should be useful enough for many things though.
-Query parameters Query parameters are passed via POST only, and all results are in a fairly verbose JSON format.
-apikey - Your API key. These can be generated in your Settings page, when logged in to DBHub.</description>
+      <description>For anyone wanting to run SQL queries against their uploaded databases, there&amp;rsquo;s now an API server: https://api.dbhub.io&#xA;As a starting point, there&amp;rsquo;s just one API call (/v1/query), and it only runs SELECT queries (eg read only database). That should be useful enough for many things though.&#xA;Query parameters Query parameters are passed via POST only, and all results are in a fairly verbose JSON format.&#xA;apikey - Your API key. These can be generated in your Settings page, when logged in to DBHub.</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.12.0 release now available</title>
       <link>/blog/portableapp-for-3-12-0-release-now-available/</link>
       <pubDate>Thu, 18 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-12-0-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
     </item>
-    
     <item>
       <title>Version 3.12.0 released</title>
       <link>/blog/version-3-12-0-released/</link>
       <pubDate>Tue, 16 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-0-released/</guid>
       <description>Downloads DB.Browser.for.SQLite-3.12.0-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-win64.zip - .zip (no installer) for 64-bit Windows SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe - PortableApp for Windows DB.Browser.for.SQLite-3.12.0.dmg - Standard package for macOS Highlights Better table editing SQLite 3.25.0 added support for renaming columns with the ALTER TABLE command (previously you had to create a new table with the renamed column, copy all data over, delete the old table, then rename the new table - even leaving out some details of the process here&amp;hellip;).</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.0</title>
       <link>/blog/first-release-candidate-for-3-12-0/</link>
       <pubDate>Mon, 08 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-0/</guid>
-      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.
-Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
+      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.12.0</title>
       <link>/blog/first-alpha-release-for-3-12-0/</link>
       <pubDate>Wed, 15 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-12-0/</guid>
-      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.
-Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
+      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
     </item>
-    
     <item>
       <title>Adding basic visualisation capability to dbhub.io</title>
       <link>/blog/adding-basic-visualisation-capability-to-dbhub-io/</link>
       <pubDate>Wed, 08 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/adding-basic-visualisation-capability-to-dbhub-io/</guid>
-      <description>We&amp;rsquo;ve begun adding the first visualisation pieces to DBHub.io, so people can display charts from their data.
-eg:
-This is only the starting point (eg a simple vertical bar chart) while we experiment, to find a good workflow that&amp;rsquo;s easy for people to use + customise.
-We&amp;rsquo;re aiming to add several more chart types to choose from, and there being a selection of easy-to-use predefined templates as well.
-Advanced users will ideally be able to input their own SQL queries for generating the data points to visualise.</description>
+      <description>We&amp;rsquo;ve begun adding the first visualisation pieces to DBHub.io, so people can display charts from their data.&#xA;eg:&#xA;This is only the starting point (eg a simple vertical bar chart) while we experiment, to find a good workflow that&amp;rsquo;s easy for people to use + customise.&#xA;We&amp;rsquo;re aiming to add several more chart types to choose from, and there being a selection of easy-to-use predefined templates as well.&#xA;Advanced users will ideally be able to input their own SQL queries for generating the data points to visualise.</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.11.2 release now available</title>
       <link>/blog/portableapp-for-3-11-2-release-now-available/</link>
       <pubDate>Tue, 07 May 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-11-2-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
     </item>
-    
     <item>
       <title>New landing page for DBHub.io</title>
       <link>/blog/new-landing-page-for-dbhub-io/</link>
       <pubDate>Fri, 26 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-landing-page-for-dbhub-io/</guid>
-      <description>Our sister website, DBHub.io - where people can backup their databases, share them with others, and collaboratively develop data - has a proper landing page from today:
-https://dbhub.io
-It required quite a lot of effort to assemble, even though it&amp;rsquo;s just a simple description, screenshots (click them!), and an overview video. 😉
-Please take a look, create an account (it&amp;rsquo;s free), and try things out.
-The website code is fully Open Source, and is gaining interesting + useful capabilities over time.</description>
+      <description>Our sister website, DBHub.io - where people can backup their databases, share them with others, and collaboratively develop data - has a proper landing page from today:&#xA;https://dbhub.io&#xA;It required quite a lot of effort to assemble, even though it&amp;rsquo;s just a simple description, screenshots (click them!), and an overview video. &amp;#x1f609;&#xA;Please take a look, create an account (it&amp;rsquo;s free), and try things out.&#xA;The website code is fully Open Source, and is gaining interesting + useful capabilities over time.</description>
     </item>
-    
     <item>
       <title>Standard username/password logins now working for DBHub.io</title>
       <link>/blog/standard-username-password-logins-now-working-for-dbhub-io/</link>
       <pubDate>Wed, 10 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/standard-username-password-logins-now-working-for-dbhub-io/</guid>
-      <description>A small, but important, update about DBHub.io logins. 😉
-People can now create accounts using their own username/password again, instead of needing to login via GitHub, Google, or LinkedIn.
-It used to work (ages ago), but Auth0 found a security problem with the version of NodeJS they were using, so disabled it for everyone last year. It was fixable by changing some stuff, which has now been done.
-On a related note&amp;hellip; login (using username/password) only works if &amp;ldquo;3rd party cookies&amp;rdquo; aren&amp;rsquo;t blocked in your web browser.</description>
+      <description>A small, but important, update about DBHub.io logins. &amp;#x1f609;&#xA;People can now create accounts using their own username/password again, instead of needing to login via GitHub, Google, or LinkedIn.&#xA;It used to work (ages ago), but Auth0 found a security problem with the version of NodeJS they were using, so disabled it for everyone last year. It was fixable by changing some stuff, which has now been done.&#xA;On a related note&amp;hellip; login (using username/password) only works if &amp;ldquo;3rd party cookies&amp;rdquo; aren&amp;rsquo;t blocked in your web browser.</description>
     </item>
-    
     <item>
       <title>New download and daily users stats page</title>
       <link>/blog/new-download-daily-users-stats-page/</link>
       <pubDate>Tue, 09 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-download-daily-users-stats-page/</guid>
-      <description>Today we added a new &amp;ldquo;Stats&amp;rdquo; page, showing the number of daily downloads and daily users:
-https://sqlitebrowser.org/stats/
-The graphs are generated using Redash, and should automatically update every 10 minutes:
-https://redash.io
-Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite 😉).
-It&amp;rsquo;s running in a very low end virtual machine (eg cheap), and there&amp;rsquo;s no proper caching layer yet, so it may be a bit slow to load.</description>
+      <description>Today we added a new &amp;ldquo;Stats&amp;rdquo; page, showing the number of daily downloads and daily users:&#xA;https://sqlitebrowser.org/stats/&#xA;The graphs are generated using Redash, and should automatically update every 10 minutes:&#xA;https://redash.io&#xA;Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite &amp;#x1f609;).&#xA;It&amp;rsquo;s running in a very low end virtual machine (eg cheap), and there&amp;rsquo;s no proper caching layer yet, so it may be a bit slow to load.</description>
     </item>
-    
     <item>
       <title>Version 3.11.2 released</title>
       <link>/blog/version-3-11-2-released/</link>
       <pubDate>Thu, 04 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-2-released/</guid>
-      <description>This is a minor bug fix release in the 3.11.x series
-Bug fixes and enhancements since 3.11.1 Enable &amp;lsquo;Edit Database Cell&amp;rsquo; when view is editable (#1756) DB browser crashes when I try to attach additional database to current one (#1758) CASE-SENSITIVITY: Error importing data from SQL file: cannot start a transaction within a transaction (#1764) Cell edit window considers binary data to be text/numeric if first byte is in ascii range (#1772) Crashes when browsing a empty view with view editing enabled (#1774) Trying to save after successfull import fails (#1777) Attach encrypted database results in Out of Memory Error (#1799) File is not a database (#1814) Can&amp;rsquo;t remove password from an encrypted database any more (#1829) grammar: Fix keywords as table name and keywords as column name (1a59c8cbda47684dfc0b55283fc6fdb396adc832) Updated translation strings Korean (#1600) Brazilian Portuguese (#1830) Italian (#1833) German (e2ad5459d569801f9a635391f774e81ca1009e85) Include SQLite 3.</description>
+      <description>This is a minor bug fix release in the 3.11.x series&#xA;Bug fixes and enhancements since 3.11.1 Enable &amp;lsquo;Edit Database Cell&amp;rsquo; when view is editable (#1756) DB browser crashes when I try to attach additional database to current one (#1758) CASE-SENSITIVITY: Error importing data from SQL file: cannot start a transaction within a transaction (#1764) Cell edit window considers binary data to be text/numeric if first byte is in ascii range (#1772) Crashes when browsing a empty view with view editing enabled (#1774) Trying to save after successfull import fails (#1777) Attach encrypted database results in Out of Memory Error (#1799) File is not a database (#1814) Can&amp;rsquo;t remove password from an encrypted database any more (#1829) grammar: Fix keywords as table name and keywords as column name (1a59c8cbda47684dfc0b55283fc6fdb396adc832) Updated translation strings Korean (#1600) Brazilian Portuguese (#1830) Italian (#1833) German (e2ad5459d569801f9a635391f774e81ca1009e85) Include SQLite 3.</description>
     </item>
-    
     <item>
       <title>Dark theme support in our nightly builds</title>
       <link>/blog/dark-theme-support-in-our-nightly-builds/</link>
       <pubDate>Sat, 02 Mar 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/dark-theme-support-in-our-nightly-builds/</guid>
-      <description>Thanks to the dedicated efforts of @mgrojo, our nightly builds now include a &amp;ldquo;Dark style&amp;rdquo; theme courtesy of the QDarkStyleSheet project:
-To activate it, choose &amp;ldquo;Dark style&amp;rdquo; from the &amp;ldquo;Application Style&amp;rdquo; dropdown in Preferences→General:
-To turn it off, choose &amp;ldquo;Follow the desktop style&amp;rdquo; instead.
-The nightly builds for windows and macOS are here:
-https://nightlies.sqlitebrowser.org/latest/
-The nightly builds for Ubuntu Linux are here:
-https://sqlitebrowser.org/dl/#nightly-builds-1</description>
+      <description>Thanks to the dedicated efforts of @mgrojo, our nightly builds now include a &amp;ldquo;Dark style&amp;rdquo; theme courtesy of the QDarkStyleSheet project:&#xA;To activate it, choose &amp;ldquo;Dark style&amp;rdquo; from the &amp;ldquo;Application Style&amp;rdquo; dropdown in Preferences→General:&#xA;To turn it off, choose &amp;ldquo;Follow the desktop style&amp;rdquo; instead.&#xA;The nightly builds for windows and macOS are here:&#xA;https://nightlies.sqlitebrowser.org/latest/&#xA;The nightly builds for Ubuntu Linux are here:&#xA;https://sqlitebrowser.org/dl/#nightly-builds-1</description>
     </item>
-    
     <item>
       <title>macOS installer rebuilt for 3.11.1</title>
       <link>/blog/macos-installer-rebuilt-for-3-11-1/</link>
       <pubDate>Sat, 23 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/macos-installer-rebuilt-for-3-11-1/</guid>
-      <description>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &amp;ldquo;light theme mode&amp;rdquo; (the Aqua look) on macOS Mojave. 😄
-https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg
-It&amp;rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&amp;rsquo;t yet properly support. Without this workaround, the colour pallete was unusable in important places. eg white on white when browsing data 😦
-Jesse Jackson, thank you so much for showing us how to fix this problem.</description>
+      <description>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &amp;ldquo;light theme mode&amp;rdquo; (the Aqua look) on macOS Mojave. &amp;#x1f604;&#xA;https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg&#xA;It&amp;rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&amp;rsquo;t yet properly support. Without this workaround, the colour pallete was unusable in important places. eg white on white when browsing data &amp;#x1f626;&#xA;Jesse Jackson, thank you so much for showing us how to fix this problem.</description>
     </item>
-    
     <item>
       <title>Version 3.11.1 released</title>
       <link>/blog/version-3-11-1-released/</link>
       <pubDate>Mon, 18 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-1-released/</guid>
-      <description>Note that this is effectively 3.11.0 from last week, with a critical bug fix on top + some other additional fixes.
-Note 2 - If you&amp;rsquo;re using Dark Mode on macOS Mojave, Do Not download this release. Dark Mode support is broken (badly) on MacOS. It should (hopefully) be fixed in the next point release.
-Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support on Linux Dark mode support for windows and macOS isn&amp;rsquo;t working yet.</description>
+      <description>Note that this is effectively 3.11.0 from last week, with a critical bug fix on top + some other additional fixes.&#xA;Note 2 - If you&amp;rsquo;re using Dark Mode on macOS Mojave, Do Not download this release. Dark Mode support is broken (badly) on MacOS. It should (hopefully) be fixed in the next point release.&#xA;Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support on Linux Dark mode support for windows and macOS isn&amp;rsquo;t working yet.</description>
     </item>
-    
     <item>
       <title>Version 3.11.0 pulled - encrypting databases non-functional</title>
       <link>/blog/version-3-11-0-pulled/</link>
       <pubDate>Mon, 11 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-0-pulled/</guid>
-      <description>A serious bug has been found in the recent 3.11.0 release&amp;hellip; newly encrypting databases doesn&amp;rsquo;t work (#1732), instead displaying an error message. 😦
-Existing databases - encrypted or not - can be opened without problem. The problem only occurs when attempting to newly encrypt a database.
-The links on our download page have been reverted back to the prior stable release (3.10.1) for now, while we look into this.
-There will probably be a 3.</description>
+      <description>A serious bug has been found in the recent 3.11.0 release&amp;hellip; newly encrypting databases doesn&amp;rsquo;t work (#1732), instead displaying an error message. &amp;#x1f626;&#xA;Existing databases - encrypted or not - can be opened without problem. The problem only occurs when attempting to newly encrypt a database.&#xA;The links on our download page have been reverted back to the prior stable release (3.10.1) for now, while we look into this.&#xA;There will probably be a 3.</description>
     </item>
-    
     <item>
       <title>Added public web stats using Fathom</title>
       <link>/blog/added-public-web-stats-using-fathom/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-public-web-stats-using-fathom/</guid>
-      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.
-The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.
-PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
+      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.&#xA;The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.&#xA;PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
     </item>
-    
     <item>
       <title>Version 3.11.0 released</title>
       <link>/blog/version-3-11-0-released/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-0-released/</guid>
       <description>Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support Multi-threaded loading of data Default quotes changed to double quotes Add Record dialog Printing support The math extensions for SQLite are included in the windows and macOS installers @SilvioGrosso has kindly created a video showing how to load the math extensions on windows Downloads DB.</description>
     </item>
-    
     <item>
       <title>Updated our website!</title>
       <link>/blog/new-website/</link>
       <pubDate>Thu, 31 Jan 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-website/</guid>
-      <description>Experimenting with a new approach for the DB Browser for SQLite website, as the old 1-page website was difficult to expand with blog/info on what we&amp;rsquo;ve been working on.
-This new layout - using Hugo and blogdown - should be a decent foundation, and is fairly customisable.
-It also has many available themes, which we&amp;rsquo;ll likely experiment with too.</description>
+      <description>Experimenting with a new approach for the DB Browser for SQLite website, as the old 1-page website was difficult to expand with blog/info on what we&amp;rsquo;ve been working on.&#xA;This new layout - using Hugo and blogdown - should be a decent foundation, and is fairly customisable.&#xA;It also has many available themes, which we&amp;rsquo;ll likely experiment with too.</description>
     </item>
-    
     <item>
       <title>Third beta release of 3.11.0</title>
       <link>/blog/third-beta-release-of-3-11-0y/</link>
       <pubDate>Thu, 13 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/third-beta-release-of-3-11-0y/</guid>
       <description>The third beta builds for our next major release are ready for testing. Please try them out, and report any weirdness.</description>
     </item>
-    
     <item>
       <title>Second beta release of 3.11.0</title>
       <link>/blog/second-beta-release-of-3-11-0/</link>
       <pubDate>Wed, 12 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-of-3-11-0/</guid>
       <description>The second beta builds for our next major release are ready.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.11.0</title>
       <link>/blog/first-beta-release-of-3-11-0/</link>
       <pubDate>Tue, 27 Nov 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-11-0/</guid>
       <description>The first beta builds for our next major release are ready for testing.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.11.0</title>
       <link>/blog/first-alpha-release-for-3-11-0/</link>
       <pubDate>Wed, 10 Oct 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-11-0/</guid>
       <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.</description>
     </item>
-    
     <item>
       <title>New download servers</title>
       <link>/blog/new-download-servers/</link>
       <pubDate>Thu, 09 Aug 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-download-servers/</guid>
       <description>We&amp;rsquo;ve just started testing a new download server cluster. If anything seems weird with our downloads, please report it here.</description>
     </item>
-    
     <item>
       <title>Patreon account created</title>
       <link>/blog/patreon-account-created/</link>
       <pubDate>Fri, 08 Jun 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/patreon-account-created/</guid>
-      <description>We&amp;rsquo;ve just created a Patreon account. Please become a Patron of DB Browser for SQLite! 😄</description>
+      <description>We&amp;rsquo;ve just created a Patreon account. Please become a Patron of DB Browser for SQLite! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Windows MSI installers now available</title>
       <link>/blog/windows-msi-installers-now-available/</link>
       <pubDate>Sat, 02 Jun 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/windows-msi-installers-now-available/</guid>
       <description>Windows MSI installers are now available on our nightly build server!</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.10.1</title>
       <link>/blog/portableapp-version-of-3-10-1/</link>
       <pubDate>Thu, 28 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-10-1/</guid>
-      <description>Added PortableApp version of 3.10.1. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.10.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.10.1 released</title>
       <link>/blog/version-3-10-1-released/</link>
       <pubDate>Wed, 20 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-10-1-released/</guid>
       <description>DB Browser for SQLite 3.10.1 has been released! :D</description>
     </item>
-    
     <item>
       <title>Removed continuous AppImage builds for Linux</title>
       <link>/blog/removed-continuous-appimage-builds-for-linux/</link>
       <pubDate>Fri, 08 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/removed-continuous-appimage-builds-for-linux/</guid>
       <description>Removed the continuous AppImage builds for Linux due to problems with the upload script.</description>
     </item>
-    
     <item>
       <title>AppImage builds for Linux</title>
       <link>/blog/appimage-builds-for-linux/</link>
       <pubDate>Sat, 02 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/appimage-builds-for-linux/</guid>
       <description>AppImage builds for Linux - always built from the latest DB4S commit - are now online.</description>
     </item>
-    
     <item>
       <title>Version 3.10.0 released</title>
       <link>/blog/version-3-10-0-released/</link>
       <pubDate>Sun, 20 Aug 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-10-0-released/</guid>
-      <description>DB Browser for SQLite 3.10.0 has been released! Yay! 😀</description>
+      <description>DB Browser for SQLite 3.10.0 has been released! Yay! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>Second beta release for 3.10.0</title>
       <link>/blog/second-beta-release-for-3-10-0/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-for-3-10-0/</guid>
       <description>The second beta release for our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
     <item>
       <title>First (beta) DBHub.io server with DB4S integration is online</title>
       <link>/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/</link>
       <pubDate>Sat, 29 Jul 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/</guid>
-      <description>The first &amp;ldquo;db4s-beta&amp;rdquo; server is now online, which DB4S 3.10.0-beta can store/retrieve databases in.
-Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). 😄 Don&amp;rsquo;t store important data in it yet though, as we don&amp;rsquo;t have backups set up yet.</description>
+      <description>The first &amp;ldquo;db4s-beta&amp;rdquo; server is now online, which DB4S 3.10.0-beta can store/retrieve databases in.&#xA;Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). :smile: Don&amp;rsquo;t store important data in it yet though, as we don&amp;rsquo;t have backups set up yet.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.10.0</title>
       <link>/blog/first-beta-release-of-3-10-0/</link>
       <pubDate>Fri, 21 Jul 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-10-0/</guid>
       <description>The first beta release of our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
     <item>
       <title>Nightly builds now using static URLs</title>
       <link>/blog/nightly-builds-now-using-static-urls/</link>
       <pubDate>Wed, 17 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/nightly-builds-now-using-static-urls/</guid>
       <description>Our latest nightly builds now use static URLs. Useful for bookmarking and automation.</description>
     </item>
-    
     <item>
       <title>WinXP version for 3.9.1</title>
       <link>/blog/winxp-version-for-3-9-1/</link>
       <pubDate>Sun, 14 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/winxp-version-for-3-9-1/</guid>
       <description>Due to popular demand, there is now a Windows XP compatible download.</description>
     </item>
-    
     <item>
       <title>Rebuilt OSX binary for v3.9.1</title>
       <link>/blog/rebuilt-osx-binary-for-v3-9-1/</link>
       <pubDate>Sat, 17 Dec 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/rebuilt-osx-binary-for-v3-9-1/</guid>
       <description>The v3.9.1 binary for OSX has been rebuilt using Qt 5.7.1, to fix an important colour display problem on macOS Sierra.</description>
     </item>
-    
     <item>
       <title>Initial DBHub.io server online</title>
       <link>/blog/initial-dbhub-io-server-online/</link>
       <pubDate>Thu, 15 Dec 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/initial-dbhub-io-server-online/</guid>
-      <description>An initial DBHub.io server is online, running our latest development code. Testing and feedback is encouraged.
-Note - The data on this server will probably be wiped/reset every few days.</description>
+      <description>An initial DBHub.io server is online, running our latest development code. Testing and feedback is encouraged.&#xA;Note - The data on this server will probably be wiped/reset every few days.</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.9.1</title>
       <link>/blog/portableapp-for-3-9-1/</link>
       <pubDate>Thu, 20 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-9-1/</guid>
-      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! 😄</description>
+      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>New Qt5 based nightly builds online</title>
       <link>/blog/new-qt5-based-nightly-builds-online/</link>
       <pubDate>Mon, 17 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-qt5-based-nightly-builds-online/</guid>
       <description>New Qt5 based nightly builds are online.</description>
     </item>
-    
     <item>
       <title>Version 3.9.1 released</title>
       <link>/blog/version-3-9-1-released/</link>
       <pubDate>Mon, 03 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-1-released/</guid>
       <description>Version 3.9.1 released. Mostly bug fixes.</description>
     </item>
-    
     <item>
       <title>New sister project: DBHub.io</title>
       <link>/blog/new-sister-project-dbhub-io/</link>
       <pubDate>Mon, 26 Sep 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-sister-project-dbhub-io/</guid>
-      <description>Added first page for our new sister project: DBHub.io. Take a look! 😄</description>
+      <description>Added first page for our new sister project: DBHub.io. Take a look! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.9.0</title>
       <link>/blog/portableapp-version-of-3-9-0/</link>
       <pubDate>Thu, 08 Sep 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-9-0/</guid>
-      <description>Added PortableApp download for version 3.9.0. Thanks John! 😄</description>
+      <description>Added PortableApp download for version 3.9.0. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.9.0 released</title>
       <link>/blog/version-3-9-0-released/</link>
       <pubDate>Wed, 24 Aug 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-0-released/</guid>
       <description>The next major release, version 3.9.0 is ready for download!</description>
     </item>
-    
     <item>
       <title>Version 3.9.0 beta1 released</title>
       <link>/blog/version-3-9-0-beta1-released/</link>
       <pubDate>Sun, 14 Aug 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-0-beta1-released/</guid>
-      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.
-[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. 😄</description>
+      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.&#xA;[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. :smile:</description>
     </item>
-    
     <item>
       <title>Test build with SQLCipher for Win64</title>
       <link>/blog/test-build-with-sqlcipher-for-win64/</link>
       <pubDate>Wed, 04 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/test-build-with-sqlcipher-for-win64/</guid>
-      <description>Added an initial test build with encryption support on 64-bit Windows. Give it a go! 😀</description>
+      <description>Added an initial test build with encryption support on 64-bit Windows. Give it a go! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>Added 64-bit Windows development instructions to the wiki</title>
       <link>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</link>
       <pubDate>Mon, 02 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</guid>
       <description>Added full 64-bit Windows development instructions to the wiki, with many screenshots.</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.8.0</title>
       <link>/blog/portableapp-version-of-3-8-0/</link>
       <pubDate>Sun, 17 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-8-0/</guid>
-      <description>Added PortableApp version of 3.8.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.8.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>New 3.8.0 downloads for MacOS X</title>
       <link>/blog/new-3-8-0-downloads-for-macos-x/</link>
       <pubDate>Wed, 06 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-3-8-0-downloads-for-macos-x/</guid>
       <description>New 3.8.0 downloads for MacOS X today, to fix a crashing bug.</description>
     </item>
-    
     <item>
       <title>Fixed the downloads for v3.8.0</title>
       <link>/blog/fixed-the-downloads-for-v3-8-0/</link>
       <pubDate>Sat, 26 Dec 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/fixed-the-downloads-for-v3-8-0/</guid>
       <description>New (fixed) downloads for version 3.8.0 are available!</description>
     </item>
-    
     <item>
       <title>Version 3.8.0 released</title>
       <link>/blog/version-3-8-0-released/</link>
       <pubDate>Fri, 25 Dec 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-8-0-released/</guid>
-      <description>Version 3.8.0 released!
-Buggy release, removed for now. Keep using 3.7.0.</description>
+      <description>Version 3.8.0 released!&#xA;Buggy release, removed for now. Keep using 3.7.0.</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.7.0</title>
       <link>/blog/portableapp-version-of-3-7-0/</link>
       <pubDate>Tue, 07 Jul 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-7-0/</guid>
-      <description>Added PortableApp version of 3.7.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.7.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.7.0 released</title>
       <link>/blog/version-3-7-0-released/</link>
       <pubDate>Sun, 14 Jun 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-7-0-released/</guid>
-      <description>Version 3.7.0 released. 😄</description>
+      <description>Version 3.7.0 released. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.6.0v3</title>
       <link>/blog/portableapp-version-of-3-6-0v3/</link>
       <pubDate>Sat, 09 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-6-0v3/</guid>
-      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. 😄</description>
+      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Windows XP support added back</title>
       <link>/blog/windows-xp-support-added-back/</link>
       <pubDate>Tue, 05 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/windows-xp-support-added-back/</guid>
-      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. 😉</description>
+      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. &amp;#x1f609;</description>
     </item>
-    
     <item>
       <title>Fixed windows installer for 3.6.0</title>
       <link>/blog/fixed-windows-installer-for-3-6-0/</link>
       <pubDate>Wed, 29 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/fixed-windows-installer-for-3-6-0/</guid>
       <description>The Windows installer for v3.6.0 has been fixed (was missing .dlls).</description>
     </item>
-    
     <item>
       <title>Problems with the windows installer for 3.6.0</title>
       <link>/blog/problems-with-the-windows-installer-for-3-6-0/</link>
       <pubDate>Tue, 28 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/problems-with-the-windows-installer-for-3-6-0/</guid>
       <description>Problems with the windows installer for 3.6.0. Took those down for today.</description>
     </item>
-    
     <item>
       <title>Version 3.6.0 released</title>
       <link>/blog/version-3-6-0-released/</link>
       <pubDate>Mon, 27 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-6-0-released/</guid>
       <description>Version 3.6.0 released. Lots of enhancements over all previous releases. You want this!</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.5.1</title>
       <link>/blog/portableapp-version-of-3-5-1/</link>
       <pubDate>Tue, 17 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-5-1/</guid>
-      <description>Added PortableApp download for v3.5.1. Thanks John. 😄</description>
+      <description>Added PortableApp download for v3.5.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.5.1 released</title>
       <link>/blog/version-3-5-1-released/</link>
       <pubDate>Sun, 08 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-5-1-released/</guid>
-      <description>Version 3.5.1 released. Fixes bugs in 3.5.0. 😄</description>
+      <description>Version 3.5.1 released. Fixes bugs in 3.5.0. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.5.0 released</title>
       <link>/blog/version-3-5-0-released/</link>
       <pubDate>Sat, 31 Jan 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-5-0-released/</guid>
       <description>Version 3.5.0 released. Adds optional SQLCipher support for MacOS X and Linux.</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.4.0</title>
       <link>/blog/portableapp-version-of-3-4-0/</link>
       <pubDate>Thu, 29 Jan 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-4-0/</guid>
       <description>Added PortableApp download for v3.4.0.</description>
     </item>
-    
     <item>
       <title>Version 3.4.0 released</title>
       <link>/blog/version-3-4-0-released/</link>
       <pubDate>Wed, 29 Oct 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-4-0-released/</guid>
       <description>Version 3.4.0 released. Huge improvements in .csv handling and other tweaks.</description>
     </item>
-    
     <item>
       <title>Project renamed... (again)</title>
       <link>/blog/project-renamed-again/</link>
       <pubDate>Tue, 23 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/project-renamed-again/</guid>
-      <description>It turned out our previous &amp;ldquo;new&amp;rdquo; project name was already taken. Oops.
-So, our project has now been renamed to &amp;ldquo;DB Browser for SQLite&amp;rdquo;.
-Hopefully this is the final rename. 😄</description>
+      <description>It turned out our previous &amp;ldquo;new&amp;rdquo; project name was already taken. Oops.&#xA;So, our project has now been renamed to &amp;ldquo;DB Browser for SQLite&amp;rdquo;.&#xA;Hopefully this is the final rename. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Nightly OSX builds are online</title>
       <link>/blog/nightly-osx-builds-are-online/</link>
       <pubDate>Mon, 15 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/nightly-osx-builds-are-online/</guid>
       <description>Nightly builds for OSX now available here.</description>
     </item>
-    
     <item>
       <title>Released new v3.3.1 .dmg for OSX</title>
       <link>/blog/released-new-v3-3-1-dmg-for-osx/</link>
       <pubDate>Tue, 02 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/released-new-v3-3-1-dmg-for-osx/</guid>
       <description>Released a new version 3.3.1 .dmg for OSX. The previous one had an old SQLite version in it.</description>
     </item>
-    
     <item>
       <title>Version 3.3.1 released</title>
       <link>/blog/version-3-3-1-released/</link>
       <pubDate>Sun, 31 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-3-1-released/</guid>
       <description>Version 3.3.1 released, using the new name. No functional changes from 3.3.0.</description>
     </item>
-    
     <item>
       <title>Project renamed</title>
       <link>/blog/project-renamed/</link>
       <pubDate>Thu, 28 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/project-renamed/</guid>
-      <description>Project renamed to &amp;ldquo;Database Browser for SQLite&amp;rdquo;, at Richard Hipp&amp;rsquo;s request. 😄</description>
+      <description>Project renamed to &amp;ldquo;Database Browser for SQLite&amp;rdquo;, at Richard Hipp&amp;rsquo;s request. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.3.0 released</title>
       <link>/blog/version-3-3-0-released/</link>
       <pubDate>Sun, 24 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-3-0-released/</guid>
       <description>Version 3.3.0 released. Several bug fixes and improvements, a recommended upgrade.</description>
     </item>
-    
     <item>
       <title>Version 3.2.0 released</title>
       <link>/blog/version-3-2-0-released/</link>
       <pubDate>Sun, 06 Jul 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-2-0-released/</guid>
       <description>Version 3.2.0 released. Lots of improvements, a recommended upgrade.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/blog/initial-dbhub-io-server-online/index.html
+++ b/docs/blog/initial-dbhub-io-server-online/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Initial DBHub.io server online - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/linux-appimage-available/index.html
+++ b/docs/blog/linux-appimage-available/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Linux AppImage of 3.12.2 release available - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -83,7 +84,7 @@
 </ul>
 <p>That should work on most Linux (x86_64) distributions, and should help people running
 older software to use our new releases.</p>
-<p>Good stuff Nikolay! 😀</p>
+<p>Good stuff Nikolay! &#x1f600;</p>
 
     </div>
   </article>
@@ -95,9 +96,9 @@ older software to use our new releases.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/live-databases-are-now-live/index.html
+++ b/docs/blog/live-databases-are-now-live/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Live databases are now .. live! - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -95,9 +96,9 @@ If you switch to <strong>Live</strong> mode, you can use <a href="https://api.db
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/live-databases-can-be-public/index.html
+++ b/docs/blog/live-databases-can-be-public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Live databases can be public .. and more updates - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -124,9 +125,9 @@ If you&rsquo;re using databases which hit this limit, please raise a <a href="ht
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/macos-installer-rebuilt-for-3-11-1/index.html
+++ b/docs/blog/macos-installer-rebuilt-for-3-11-1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>macOS installer rebuilt for 3.11.1 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,10 +74,10 @@
     
 
     <div class="article-content">
-      <p>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &ldquo;light theme mode&rdquo; (the Aqua look) on macOS Mojave. 😄</p>
+      <p>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &ldquo;light theme mode&rdquo; (the Aqua look) on macOS Mojave. &#x1f604;</p>
 <p>    <a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg">https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg</a></p>
-<p>It&rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&rsquo;t yet properly support.  Without this workaround, the colour pallete was unusable in important places.  eg white on white when browsing data 😦</p>
-<p><a href="https://github.com/jsejcksn">Jesse Jackson</a>, thank you so much for <a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/1751#issuecomment-466618493">showing us how to fix</a> this problem. 😄</p>
+<p>It&rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&rsquo;t yet properly support.  Without this workaround, the colour pallete was unusable in important places.  eg white on white when browsing data &#x1f626;</p>
+<p><a href="https://github.com/jsejcksn">Jesse Jackson</a>, thank you so much for <a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/1751#issuecomment-466618493">showing us how to fix</a> this problem. &#x1f604;</p>
 
     </div>
   </article>
@@ -88,9 +89,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/more-webui-related-updates/index.html
+++ b/docs/blog/more-webui-related-updates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>More webUI related updates - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -109,9 +110,9 @@ We did say we are hard at work on the development of this.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-3-8-0-downloads-for-macos-x/index.html
+++ b/docs/blog/new-3-8-0-downloads-for-macos-x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New 3.8.0 downloads for MacOS X - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-api-for-remotely-executing-sqlite-queries/index.html
+++ b/docs/blog/new-api-for-remotely-executing-sqlite-queries/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New API for remotely executing SQLite queries - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -104,7 +105,7 @@ ORDER BY table1.id;
        https://api.dbhub.io/v1/query
 </code></pre><p>The results will be returned in a fairly verbose JSON format which includes data type information for each field, the field name, and the value for that field:</p>
 <pre tabindex="0"><code>[[{&#34;Name&#34;:&#34;Name&#34;,&#34;Type&#34;:3,&#34;Value&#34;:&#34;Foo&#34;} ... (shortened for clarity)
-</code></pre><p>We think that&rsquo;s a good enough starting point, but if you&rsquo;d like to use this and we&rsquo;re missing something, or something isn&rsquo;t working for you, please <a href="https://github.com/sqlitebrowser/dbhub.io/issues">let us know via GitHub Issues</a>. 😄</p>
+</code></pre><p>We think that&rsquo;s a good enough starting point, but if you&rsquo;d like to use this and we&rsquo;re missing something, or something isn&rsquo;t working for you, please <a href="https://github.com/sqlitebrowser/dbhub.io/issues">let us know via GitHub Issues</a>. &#x1f604;</p>
 
     </div>
   </article>
@@ -116,9 +117,9 @@ ORDER BY table1.id;
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-download-daily-users-stats-page/index.html
+++ b/docs/blog/new-download-daily-users-stats-page/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New download and daily users stats page - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -77,7 +78,7 @@
 <p>    <a href="https://sqlitebrowser.org/stats/">https://sqlitebrowser.org/stats/</a></p>
 <p>The graphs are generated using Redash, and should automatically update every 10 minutes:</p>
 <p>    <a href="https://redash.io">https://redash.io</a></p>
-<p>Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite 😉).</p>
+<p>Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite &#x1f609;).</p>
 <p>It&rsquo;s running in a very low end virtual machine (eg cheap), and there&rsquo;s no proper caching layer yet, so it may be a bit slow to load.</p>
 <p>Some sort of decent caching will probably be added over the next few days.</p>
 
@@ -91,9 +92,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-download-servers/index.html
+++ b/docs/blog/new-download-servers/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New download servers - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-go-library-for-working-with-your-dbhub-io-databases/index.html
+++ b/docs/blog/new-go-library-for-working-with-your-dbhub-io-databases/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New Go library for working with your DBHub.io databases - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -81,7 +82,7 @@
       <p>For anyone with an interest in Go programming, there&rsquo;s now a library to access and query your databases on <a href="https://dbhub.io">DBHub.io</a>:</p>
 <p><a href="https://github.com/sqlitebrowser/go-dbhub">https://github.com/sqlitebrowser/go-dbhub</a></p>
 <p><a href="https://pkg.go.dev/github.com/sqlitebrowser/go-dbhub">Documentation</a> is in place, code quality <a href="https://goreportcard.com/report/github.com/sqlitebrowser/go-dbhub">is good</a>, and there are <a href="#further-examples">worked examples</a> for each function call.</p>
-<p>It&rsquo;s still in early stages of development, but seems to work well already. 😄</p>
+<p>It&rsquo;s still in early stages of development, but seems to work well already. &#x1f604;</p>
 <h3 id="what-works-now">What works now</h3>
 <ul>
 <li>Run read-only queries (eg SELECT statements) on databases, returning the results as JSON</li>
@@ -98,7 +99,7 @@
 <li>Tests for each function</li>
 <li>Upload a complete database</li>
 <li>Investigate what would be needed for this to work through the Go SQL API</li>
-<li>Anything else that people suggest and seems like a good idea 😄</li>
+<li>Anything else that people suggest and seems like a good idea &#x1f604;</li>
 </ul>
 <h3 id="requirements">Requirements</h3>
 <ul>
@@ -163,7 +164,7 @@ Query results (JSON):
 <li><strong>(Added 2020-08-04)</strong> - <a href="https://github.com/sqlitebrowser/go-dbhub/blob/master/examples/download_database/main.go">Download database</a> - Download a complete database file</li>
 <li><strong>(Added 2020-08-05)</strong> - <a href="https://github.com/sqlitebrowser/go-dbhub/blob/master/examples/metadata/main.go">Retrieve metadata</a> - Download the database metadata (size, branches, commit list, etc)</li>
 </ul>
-<p>Please try it out, <a href="https://github.com/sqlitebrowser/go-dbhub/pulls">submits PRs</a> to extend or fix things, and <a href="https://github.com/sqlitebrowser/go-dbhub/issues">report any weirdness or bugs</a> you encounter. 😄</p>
+<p>Please try it out, <a href="https://github.com/sqlitebrowser/go-dbhub/pulls">submits PRs</a> to extend or fix things, and <a href="https://github.com/sqlitebrowser/go-dbhub/issues">report any weirdness or bugs</a> you encounter. &#x1f604;</p>
 
     </div>
   </article>
@@ -175,9 +176,9 @@ Query results (JSON):
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-landing-page-for-dbhub-io/index.html
+++ b/docs/blog/new-landing-page-for-dbhub-io/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New landing page for DBHub.io - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -75,7 +76,7 @@
     <div class="article-content">
       <p>Our sister website, DBHub.io - where people can backup their databases, share them with others, and collaboratively develop data - has a proper landing page from today:</p>
 <p>    <a href="https://dbhub.io">https://dbhub.io</a></p>
-<p>It required quite a lot of effort to assemble, even though it&rsquo;s just a simple description, screenshots (click them!), and an overview video. 😉</p>
+<p>It required quite a lot of effort to assemble, even though it&rsquo;s just a simple description, screenshots (click them!), and an overview video. &#x1f609;</p>
 <p>Please take a look, create an account (it&rsquo;s free), and try things out.</p>
 <p>The website code is <a href="https://github.com/sqlitebrowser/dbhub.io">fully Open Source</a>, and is gaining interesting + useful capabilities over time.  :)</p>
 
@@ -89,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-qt5-based-nightly-builds-online/index.html
+++ b/docs/blog/new-qt5-based-nightly-builds-online/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New Qt5 based nightly builds online - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-sister-project-dbhub-io/index.html
+++ b/docs/blog/new-sister-project-dbhub-io/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>New sister project: DBHub.io - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added first page for our new sister project: <a href="https://dbhub.io">DBHub.io</a>. <a href="https://dbhub.io">Take a look!</a> 😄</p>
+      <p>Added first page for our new sister project: <a href="https://dbhub.io">DBHub.io</a>. <a href="https://dbhub.io">Take a look!</a> &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-website/index.html
+++ b/docs/blog/new-website/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Updated our website! - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +92,9 @@ likely experiment with too.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/nightly-builds-now-using-static-urls/index.html
+++ b/docs/blog/nightly-builds-now-using-static-urls/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Nightly builds now using static URLs - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/nightly-osx-builds-are-online/index.html
+++ b/docs/blog/nightly-osx-builds-are-online/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Nightly OSX builds are online - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/patreon-account-created/index.html
+++ b/docs/blog/patreon-account-created/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Patreon account created - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>We&rsquo;ve just created a Patreon account. Please <a href="https://www.patreon.com/bePatron?u=11578749">become a Patron</a> of DB Browser for SQLite! 😄</p>
+      <p>We&rsquo;ve just created a Patreon account. Please <a href="https://www.patreon.com/bePatron?u=11578749">become a Patron</a> of DB Browser for SQLite! &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-for-3-11-2-release-now-available/index.html
+++ b/docs/blog/portableapp-for-3-11-2-release-now-available/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp for 3.11.2 release now available - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-for-3-12-0-release-now-available/index.html
+++ b/docs/blog/portableapp-for-3-12-0-release-now-available/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp for 3.12.0 release now available - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-for-3-9-1/index.html
+++ b/docs/blog/portableapp-for-3-9-1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp for 3.9.1 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.9.1/SQLiteDatabaseBrowserPortable_3.9.1_English.paf.exe">version of DB4S 3.9.1</a> now available.  Thanks John! 😄</p>
+      <p>PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.9.1/SQLiteDatabaseBrowserPortable_3.9.1_English.paf.exe">version of DB4S 3.9.1</a> now available.  Thanks John! &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-10-1/index.html
+++ b/docs/blog/portableapp-version-of-3-10-1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp version of 3.10.1 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/SQLiteDatabaseBrowserPortable_3.10.1_English.paf.exe">version of 3.10.1</a>.  Thanks John. 😄</p>
+      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/SQLiteDatabaseBrowserPortable_3.10.1_English.paf.exe">version of 3.10.1</a>.  Thanks John. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-4-0/index.html
+++ b/docs/blog/portableapp-version-of-3-4-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp version of 3.4.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-5-1/index.html
+++ b/docs/blog/portableapp-version-of-3-5-1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp version of 3.5.1 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.5.1/SQLiteDatabaseBrowserPortable_3.5.1_English.paf.exe">download for v3.5.1</a>. Thanks John. 😄</p>
+      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.5.1/SQLiteDatabaseBrowserPortable_3.5.1_English.paf.exe">download for v3.5.1</a>. Thanks John. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-6-0v3/index.html
+++ b/docs/blog/portableapp-version-of-3-6-0v3/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp version of 3.6.0v3 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.6.0/SQLiteDatabaseBrowserPortable_3.6.0_English.paf.exe">version of 3.6.0v3</a>.  Many thanks again John. 😄</p>
+      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.6.0/SQLiteDatabaseBrowserPortable_3.6.0_English.paf.exe">version of 3.6.0v3</a>.  Many thanks again John. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-7-0/index.html
+++ b/docs/blog/portableapp-version-of-3-7-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp version of 3.7.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.7.0/SQLiteDatabaseBrowserPortable_3.7.0_English.paf.exe">version of 3.7.0</a>. Thanks John. 😄</p>
+      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.7.0/SQLiteDatabaseBrowserPortable_3.7.0_English.paf.exe">version of 3.7.0</a>. Thanks John. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-8-0/index.html
+++ b/docs/blog/portableapp-version-of-3-8-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp version of 3.8.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.8.0/SQLiteDatabaseBrowserPortable_3.8.0_English.paf.exe">version of 3.8.0</a>. Thanks John. 😄</p>
+      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.8.0/SQLiteDatabaseBrowserPortable_3.8.0_English.paf.exe">version of 3.8.0</a>. Thanks John. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-9-0/index.html
+++ b/docs/blog/portableapp-version-of-3-9-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>PortableApp version of 3.9.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.9.0/SQLiteDatabaseBrowserPortable_3.9.0_English.paf.exe">download for version 3.9.0</a>.  Thanks John! 😄</p>
+      <p>Added PortableApp <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.9.0/SQLiteDatabaseBrowserPortable_3.9.0_English.paf.exe">download for version 3.9.0</a>.  Thanks John! &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/problems-with-the-windows-installer-for-3-6-0/index.html
+++ b/docs/blog/problems-with-the-windows-installer-for-3-6-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Problems with the windows installer for 3.6.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/project-renamed-again/index.html
+++ b/docs/blog/project-renamed-again/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Project renamed... (again) - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -75,7 +76,7 @@
     <div class="article-content">
       <p>It turned out our previous &ldquo;new&rdquo; project name was already taken.  Oops.</p>
 <p>So, our project has now been renamed to &ldquo;DB Browser for SQLite&rdquo;.</p>
-<p>Hopefully this is the final rename. 😄</p>
+<p>Hopefully this is the final rename. &#x1f604;</p>
 
     </div>
   </article>
@@ -87,9 +88,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/project-renamed/index.html
+++ b/docs/blog/project-renamed/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Project renamed - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Project renamed to &ldquo;Database Browser for SQLite&rdquo;, at <a href="https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg85627.html">Richard Hipp&rsquo;s request</a>. 😄</p>
+      <p>Project renamed to &ldquo;Database Browser for SQLite&rdquo;, at <a href="https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg85627.html">Richard Hipp&rsquo;s request</a>. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/rebuilt-osx-binary-for-v3-9-1/index.html
+++ b/docs/blog/rebuilt-osx-binary-for-v3-9-1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Rebuilt OSX binary for v3.9.1 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/released-new-v3-3-1-dmg-for-osx/index.html
+++ b/docs/blog/released-new-v3-3-1-dmg-for-osx/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Released new v3.3.1 .dmg for OSX - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/removed-continuous-appimage-builds-for-linux/index.html
+++ b/docs/blog/removed-continuous-appimage-builds-for-linux/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Removed continuous AppImage builds for Linux - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/second-beta-release-for-3-10-0/index.html
+++ b/docs/blog/second-beta-release-for-3-10-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Second beta release for 3.10.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/second-beta-release-of-3-11-0/index.html
+++ b/docs/blog/second-beta-release-of-3-11-0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Second beta release of 3.11.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/standard-username-password-logins-now-working-for-dbhub-io/index.html
+++ b/docs/blog/standard-username-password-logins-now-working-for-dbhub-io/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Standard username/password logins now working for DBHub.io - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>A small, but important, update about <a href="https://dbhub.io">DBHub.io</a> logins. 😉</p>
+      <p>A small, but important, update about <a href="https://dbhub.io">DBHub.io</a> logins. &#x1f609;</p>
 <p>People can now create accounts using their own username/password again, instead of needing  to login via GitHub, Google, or LinkedIn.</p>
 <p>It used to work (ages ago), but Auth0 found a security problem with the version of NodeJS they were using, so disabled it for everyone last year.  It was fixable by changing some stuff, which has now been done.</p>
 <p>On a related note&hellip; login (using username/password) only works if &ldquo;3rd party cookies&rdquo; aren&rsquo;t blocked in your web browser.</p>
@@ -89,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/support-for-sqlite-extensions-added/index.html
+++ b/docs/blog/support-for-sqlite-extensions-added/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Support for SQLite extensions added - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -97,9 +98,9 @@ by these extensions, which should be very useful for a lot of people.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/test-build-with-sqlcipher-for-win64/index.html
+++ b/docs/blog/test-build-with-sqlcipher-for-win64/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Test build with SQLCipher for Win64 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Added an initial <a href="http://nightlies.sqlitebrowser.org/win64/sqlitebrowser-win64-with_sqlcipher-201605041823.exe">test build with encryption support on 64-bit Windows</a>. Give it a go! 😀</p>
+      <p>Added an initial <a href="http://nightlies.sqlitebrowser.org/win64/sqlitebrowser-win64-with_sqlcipher-201605041823.exe">test build with encryption support on 64-bit Windows</a>. Give it a go! &#x1f600;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/third-beta-release-of-3-11-0y/index.html
+++ b/docs/blog/third-beta-release-of-3-11-0y/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Third beta release of 3.11.0 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-10-0-released/index.html
+++ b/docs/blog/version-3-10-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.10.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>DB Browser for SQLite <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.10.0">3.10.0 has been released</a>!  Yay! 😀</p>
+      <p>DB Browser for SQLite <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.10.0">3.10.0 has been released</a>!  Yay! &#x1f600;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-10-1-released/index.html
+++ b/docs/blog/version-3-10-1-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.10.1 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-0-pulled/index.html
+++ b/docs/blog/version-3-11-0-pulled/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.11.0 pulled - encrypting databases non-functional - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,10 +74,10 @@
     
 
     <div class="article-content">
-      <p>A serious bug has been found in the recent 3.11.0 release&hellip; newly encrypting databases doesn&rsquo;t work (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/1732">#1732</a>), instead displaying an error message. 😦</p>
+      <p>A serious bug has been found in the recent 3.11.0 release&hellip; newly encrypting databases doesn&rsquo;t work (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/1732">#1732</a>), instead displaying an error message. &#x1f626;</p>
 <p>Existing databases - encrypted or not - can be opened without problem.  The problem only occurs when attempting to newly encrypt a database.</p>
 <p>The links on our download page have been reverted back to the prior stable release (3.10.1) for now, while we look into this.</p>
-<p>There will probably be a 3.11.1 release in the near future, with the problem solved. 😄</p>
+<p>There will probably be a 3.11.1 release in the near future, with the problem solved. &#x1f604;</p>
 
     </div>
   </article>
@@ -88,9 +89,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-0-released/index.html
+++ b/docs/blog/version-3-11-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.11.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -157,7 +158,7 @@ DB.Browser.for.SQLite-3.11.0-win64.msi
 <pre><code>DB.Browser.for.SQLite-3.11.0-win32.zip
 DB.Browser.for.SQLite-3.11.0-win64.zip
 </code></pre>
-<p>If you&rsquo;re not sure which one to get, try the .msi version first. 😄</p>
+<p>If you&rsquo;re not sure which one to get, try the .msi version first. &#x1f604;</p>
 <h3 id="note-on-the-macos-installer">Note on the macOS installer</h3>
 <p>The macOS installation now includes the SQLite math extensions (<code>math.dylib</code>), located in the <code>Contents/Extensions/</code> folder inside <code>DB Browser for SQLite.app</code>.</p>
 <ul>
@@ -392,9 +393,9 @@ DB.Browser.for.SQLite-3.11.0-win64.zip
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-1-released/index.html
+++ b/docs/blog/version-3-11-1-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.11.1 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,7 +92,7 @@
 <li>Better copy &amp; paste support</li>
 <li>Dark theme support on Linux
 <ul>
-<li>Dark mode support for windows and macOS isn&rsquo;t working yet. 😦</li>
+<li>Dark mode support for windows and macOS isn&rsquo;t working yet. &#x1f626;</li>
 </ul>
 </li>
 <li>Multi-threaded loading of data</li>
@@ -163,7 +164,7 @@ DB.Browser.for.SQLite-3.11.1-win64.msi
 <pre><code>DB.Browser.for.SQLite-3.11.1-win32.zip
 DB.Browser.for.SQLite-3.11.1-win64.zip
 </code></pre>
-<p>If you&rsquo;re not sure which one to get, try the .msi version first. 😄</p>
+<p>If you&rsquo;re not sure which one to get, try the .msi version first. &#x1f604;</p>
 <h3 id="note-on-the-macos-installer">Note on the macOS installer</h3>
 <p>The macOS installation now includes the SQLite math extensions (<code>math.dylib</code>), located in the <code>Contents/Extensions/</code> folder inside <code>DB Browser for SQLite.app</code>.</p>
 <ul>
@@ -413,9 +414,9 @@ DB.Browser.for.SQLite-3.11.1-win64.zip
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-2-released/index.html
+++ b/docs/blog/version-3-11-2-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.11.2 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -144,9 +145,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-12-0-released/index.html
+++ b/docs/blog/version-3-12-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.12.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -185,7 +186,7 @@
 <p>We have added proxy support to our network code. So it is finally possible to use DB4S through a proxy, for example, your company proxy. This also changes the defaults to use the system proxy configuration instead of not using any proxy at all.</p>
 </li>
 <li>
-<p>The proxy settings affect all network code. This includes the automatic update check on Windows and macOS but also the <a href="https://dbhub.io">dbhub.io</a> integration. If you have not heard of it before, dbhub.io is a cloud service which allows you to work on SQLite databases collaboratively. It is developed by the same developers as DB4S. You can check it out for free. 😄</p>
+<p>The proxy settings affect all network code. This includes the automatic update check on Windows and macOS but also the <a href="https://dbhub.io">dbhub.io</a> integration. If you have not heard of it before, dbhub.io is a cloud service which allows you to work on SQLite databases collaboratively. It is developed by the same developers as DB4S. You can check it out for free. &#x1f604;</p>
 </li>
 <li>
 <p>To change the proxy settings, open the Preferences dialog, go to the Remote tab, and click on the Configure button in the proxy section.
@@ -396,9 +397,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-12-1-released/index.html
+++ b/docs/blog/version-3-12-1-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.12.1 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -74,7 +75,7 @@
 
     <div class="article-content">
       <p>This is the first bug fix release for our 3.12.x series.</p>
-<p>There aren&rsquo;t any &ldquo;super critical <strong>must upgrade</strong>&rdquo; bugs fixed, so updating isn&rsquo;t urgent. 😄</p>
+<p>There aren&rsquo;t any &ldquo;super critical <strong>must upgrade</strong>&rdquo; bugs fixed, so updating isn&rsquo;t urgent. &#x1f604;</p>
 <h2 id="downloads">Downloads</h2>
 <ul>
 <li><a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.1/DB.Browser.for.SQLite-3.12.1-win32-v2.msi">DB.Browser.for.SQLite-3.12.1-win32-v2.msi</a> - Standard (MSI) installer for Win32 and WinXP</li>
@@ -182,9 +183,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-12-2-released/index.html
+++ b/docs/blog/version-3-12-2-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.12.2 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -76,7 +77,7 @@
       <p>This is a minor maintenance release, primarily to update the internal certificates for
 anonymous communication with the DBHub.io servers.</p>
 <p>You <strong>don&rsquo;t</strong> need to upgrade unless you&rsquo;re using DBHub.io anonymously.  If you&rsquo;re using DBHub.io
-with your own client certificate, this upgrade won&rsquo;t really do much either. 😄</p>
+with your own client certificate, this upgrade won&rsquo;t really do much either. &#x1f604;</p>
 <p>The changes in this over the 3.12.1 release include:</p>
 <ul>
 <li>Fix saving the list of extensions in the Preferences dialog (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/bd0e1feead6bb446f8a703338aa9893bf281e5b4">bd0e1feead6bb446f8a703338aa9893bf281e5b4</a>)</li>
@@ -137,9 +138,9 @@ with your own client certificate, this upgrade won&rsquo;t really do much either
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-2-0-released/index.html
+++ b/docs/blog/version-3-2-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.2.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-3-0-released/index.html
+++ b/docs/blog/version-3-3-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.3.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-3-1-released/index.html
+++ b/docs/blog/version-3-3-1-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.3.1 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-4-0-released/index.html
+++ b/docs/blog/version-3-4-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.4.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-5-0-released/index.html
+++ b/docs/blog/version-3-5-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.5.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-5-1-released/index.html
+++ b/docs/blog/version-3-5-1-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.5.1 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Version <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.5.1">3.5.1 released</a>.  Fixes bugs in 3.5.0. 😄</p>
+      <p>Version <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.5.1">3.5.1 released</a>.  Fixes bugs in 3.5.0. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-6-0-released/index.html
+++ b/docs/blog/version-3-6-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.6.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-7-0-released/index.html
+++ b/docs/blog/version-3-7-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.7.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>Version <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.7.0">3.7.0 released</a>. 😄</p>
+      <p>Version <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.7.0">3.7.0 released</a>. &#x1f604;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-8-0-released/index.html
+++ b/docs/blog/version-3-8-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.8.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-9-0-beta1-released/index.html
+++ b/docs/blog/version-3-9-0-beta1-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.9.0 beta1 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -74,7 +75,7 @@
 
     <div class="article-content">
       <p>Version <a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1">3.9.0 beta1 released</a>, with <a href="https://www.zetetic.net/sqlcipher/">SQLCipher</a> for strong encryption.</p>
-<center><u>[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1)</u>, and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. 😄</center>
+<center><u>[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1)</u>, and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. :smile:</center>
     </div>
   </article>
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-9-0-released/index.html
+++ b/docs/blog/version-3-9-0-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.9.0 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-9-1-released/index.html
+++ b/docs/blog/version-3-9-1-released/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Version 3.9.1 released - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/windows-msi-installers-now-available/index.html
+++ b/docs/blog/windows-msi-installers-now-available/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Windows MSI installers now available - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/windows-xp-support-added-back/index.html
+++ b/docs/blog/windows-xp-support-added-back/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Windows XP support added back - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -73,7 +74,7 @@
     
 
     <div class="article-content">
-      <p>The third version of the Windows installer for v3.6.0 has been added.  This version works on XP too. 😉</p>
+      <p>The third version of the Windows installer for v3.6.0 has been added.  This version works on XP too. &#x1f609;</p>
 
     </div>
   </article>
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/winxp-version-for-3-9-1/index.html
+++ b/docs/blog/winxp-version-for-3-9-1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>WinXP version for 3.9.1 - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/db4s/index.html
+++ b/docs/categories/db4s/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>db4s - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/db4s/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/db4s/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -146,9 +145,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/db4s/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/db4s/index.xml
+++ b/docs/categories/db4s/index.xml
@@ -6,105 +6,70 @@
     <description>Recent content in db4s on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 24 Oct 2022 00:00:00 +0000</lastBuildDate><atom:link href="/categories/db4s/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Mon, 24 Oct 2022 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/categories/db4s/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Apple Silicon (M1/M2/etc) macOS package available</title>
       <link>/blog/apple-silicon-macos-package-available/</link>
       <pubDate>Mon, 24 Oct 2022 00:00:00 +0000</pubDate>
-      
       <guid>/blog/apple-silicon-macos-package-available/</guid>
-      <description>We are proud to present&amp;hellip; the Apple Silicon (arm64) version of DB Browser for SQLite v3.12.2:
-https://download.sqlitebrowser.org/DB.Browser.for.SQLite-arm64-3.12.2.dmg 0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8 (SHA256 checksum) If you&amp;rsquo;re using one of Apple&amp;rsquo;s M1 or M2 based macOS devices, then this native Apple Silicon version of DB4S should work a bit better than our existing Intel based download.
-Additionally, our nightly builds for macOS now have both Intel and Apple Silicon (arm64) downloads available:
-Nightly builds using SQLite (no encryption):</description>
+      <description>We are proud to present&amp;hellip; the Apple Silicon (arm64) version of DB Browser for SQLite v3.12.2:&#xA;https://download.sqlitebrowser.org/DB.Browser.for.SQLite-arm64-3.12.2.dmg 0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8 (SHA256 checksum) If you&amp;rsquo;re using one of Apple&amp;rsquo;s M1 or M2 based macOS devices, then this native Apple Silicon version of DB4S should work a bit better than our existing Intel based download.&#xA;Additionally, our nightly builds for macOS now have both Intel and Apple Silicon (arm64) downloads available:&#xA;Nightly builds using SQLite (no encryption):</description>
     </item>
-    
     <item>
       <title>Huge thanks to DigitalOcean for sponsoring us!</title>
       <link>/blog/huge-thanks-to-digitalocean/</link>
       <pubDate>Sun, 25 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/huge-thanks-to-digitalocean/</guid>
-      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! 🕺
-We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!
-If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. 😄</description>
+      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! &amp;#x1f57a;&#xA;We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!&#xA;If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Linux AppImage of 3.12.2 release available</title>
       <link>/blog/linux-appimage-available/</link>
       <pubDate>Sat, 10 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/linux-appimage-available/</guid>
-      <description>Thanks to new team member Nikolay Zlatev, an AppImage of our recent 3.12.2 release is available:
-https://download.sqlitebrowser.org/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage ea14c7439f7e666f3e9d8cbffe9048134b87db3e2d7bf65f4146b0649536de5c (SHA256 checksum) That should work on most Linux (x86_64) distributions, and should help people running older software to use our new releases.
-Good stuff Nikolay! 😀</description>
+      <description>Thanks to new team member Nikolay Zlatev, an AppImage of our recent 3.12.2 release is available:&#xA;https://download.sqlitebrowser.org/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage ea14c7439f7e666f3e9d8cbffe9048134b87db3e2d7bf65f4146b0649536de5c (SHA256 checksum) That should work on most Linux (x86_64) distributions, and should help people running older software to use our new releases.&#xA;Good stuff Nikolay! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>Version 3.12.2 released</title>
       <link>/blog/version-3-12-2-released/</link>
       <pubDate>Tue, 18 May 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-2-released/</guid>
-      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.
-You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. 😄
-The changes in this over the 3.12.1 release include:
-Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
+      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.&#xA;You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. &amp;#x1f604;&#xA;The changes in this over the 3.12.1 release include:&#xA;Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
     </item>
-    
     <item>
       <title>Thanks to our Patreon supporters, we have a HiDPI monitor!</title>
       <link>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</link>
       <pubDate>Sat, 06 Mar 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</guid>
-      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.
-A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.
-This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
+      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.&#xA;A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.&#xA;This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
     </item>
-    
     <item>
       <title>Version 3.12.1 released</title>
       <link>/blog/version-3-12-1-released/</link>
       <pubDate>Mon, 09 Nov 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-1-released/</guid>
-      <description>This is the first bug fix release for our 3.12.x series.
-There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. 😄
-Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
+      <description>This is the first bug fix release for our 3.12.x series.&#xA;There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. &amp;#x1f604;&#xA;Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.1</title>
       <link>/blog/first-release-candidate-for-3-12-1/</link>
       <pubDate>Sun, 27 Sep 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-1/</guid>
-      <description>This is the first, and hopefully only 😉, release candidate for DB Browser for SQLite version 3.12.1.
-Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:
-Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
+      <description>This is the first, and hopefully only &amp;#x1f609;, release candidate for DB Browser for SQLite version 3.12.1.&#xA;Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:&#xA;Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.0</title>
       <link>/blog/first-release-candidate-for-3-12-0/</link>
       <pubDate>Mon, 08 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-0/</guid>
-      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.
-Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
+      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.12.0</title>
       <link>/blog/first-alpha-release-for-3-12-0/</link>
       <pubDate>Wed, 15 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-12-0/</guid>
-      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.
-Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
+      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/categories/dbhub.io/index.html
+++ b/docs/categories/dbhub.io/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>dbhub.io - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -143,9 +142,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/dbhub.io/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/dbhub.io/index.xml
+++ b/docs/categories/dbhub.io/index.xml
@@ -6,104 +6,70 @@
     <description>Recent content in dbhub.io on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate><atom:link href="/categories/dbhub.io/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/categories/dbhub.io/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Support for SQLite extensions added</title>
       <link>/blog/support-for-sqlite-extensions-added/</link>
       <pubDate>Thu, 04 May 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/support-for-sqlite-extensions-added/</guid>
-      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:
-FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
+      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:&#xA;FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
     </item>
-    
     <item>
       <title>Live databases can be public .. and more updates</title>
       <link>/blog/live-databases-can-be-public/</link>
       <pubDate>Thu, 27 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-can-be-public/</guid>
-      <description>Another week, and another series of exciting updates to DBHub.io
-Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.
-Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.
-Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
+      <description>Another week, and another series of exciting updates to DBHub.io&#xA;Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.&#xA;Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.&#xA;Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
     </item>
-    
     <item>
       <title>Execute SQL Tab Overhaul</title>
       <link>/blog/execute-sql-tab-overhaul/</link>
       <pubDate>Wed, 26 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/execute-sql-tab-overhaul/</guid>
-      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.
-While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.
-&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;
-It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
+      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.&#xA;While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.&#xA;&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;&#xA;It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
     </item>
-    
     <item>
       <title>Comments now enabled on blog posts</title>
       <link>/blog/comments-now-enabled-on-blog-posts/</link>
       <pubDate>Mon, 24 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/comments-now-enabled-on-blog-posts/</guid>
-      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.
-We look forward to hearing from you!</description>
+      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.&#xA;We look forward to hearing from you!</description>
     </item>
-    
     <item>
       <title>More webUI related updates</title>
       <link>/blog/more-webui-related-updates/</link>
       <pubDate>Fri, 07 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/more-webui-related-updates/</guid>
-      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.
-Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data
-Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
+      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.&#xA;Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data&#xA;Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
     </item>
-    
     <item>
       <title>Database sharing has been improved on DBHub.io</title>
       <link>/blog/database-sharing-has-been-improved-on-dbhub-io/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/database-sharing-has-been-improved-on-dbhub-io/</guid>
-      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.
-DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
+      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.&#xA;DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
     </item>
-    
     <item>
       <title>Go Library (go-dbhub) updated to work with Live databases</title>
       <link>/blog/go-library-updated-to-work-with-live-databases/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/go-library-updated-to-work-with-live-databases/</guid>
-      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.
-You can see the initial blog post for the Go library here .</description>
+      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.&#xA;You can see the initial blog post for the Go library here .</description>
     </item>
-    
     <item>
       <title>Live databases are now .. live!</title>
       <link>/blog/live-databases-are-now-live/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-are-now-live/</guid>
-      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.
-One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
+      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.&#xA;One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
     </item>
-    
     <item>
       <title>First release of Python library &#39;pydbhub&#39;</title>
       <link>/blog/first-release-pydbhub/</link>
       <pubDate>Sat, 05 Jun 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-pydbhub/</guid>
-      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. 😄
-It&amp;rsquo;s called pydbhub, and is available here:
-https://github.com/LeMoussel/pydbhub
-And on PyPi:
-https://pypi.org/project/pydbhub/</description>
+      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. &amp;#x1f604;&#xA;It&amp;rsquo;s called pydbhub, and is available here:&#xA;https://github.com/LeMoussel/pydbhub&#xA;And on PyPi:&#xA;https://pypi.org/project/pydbhub/</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/categories/dbhub/index.html
+++ b/docs/categories/dbhub/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>dbhub - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/dbhub/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/dbhub/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/dbhub/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/dbhub/index.xml
+++ b/docs/categories/dbhub/index.xml
@@ -6,17 +6,14 @@
     <description>Recent content in dbhub on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 25 Jul 2021 00:00:00 +0000</lastBuildDate><atom:link href="/categories/dbhub/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sun, 25 Jul 2021 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/categories/dbhub/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Huge thanks to DigitalOcean for sponsoring us!</title>
       <link>/blog/huge-thanks-to-digitalocean/</link>
       <pubDate>Sun, 25 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/huge-thanks-to-digitalocean/</guid>
-      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! 🕺
-We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!
-If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. 😄</description>
+      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! &amp;#x1f57a;&#xA;We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!&#xA;If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. &amp;#x1f604;</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Categories - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -104,9 +103,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -6,33 +6,28 @@
     <description>Recent content in Categories on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate><atom:link href="/categories/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/categories/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>dbhub.io</title>
       <link>/categories/dbhub.io/</link>
       <pubDate>Thu, 04 May 2023 00:00:00 +0000</pubDate>
-      
       <guid>/categories/dbhub.io/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>db4s</title>
       <link>/categories/db4s/</link>
       <pubDate>Mon, 24 Oct 2022 00:00:00 +0000</pubDate>
-      
       <guid>/categories/db4s/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>dbhub</title>
       <link>/categories/dbhub/</link>
       <pubDate>Sun, 25 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/categories/dbhub/</guid>
       <description></description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/dl/index.html
+++ b/docs/dl/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Downloads - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -74,7 +75,7 @@
     
 
     <div class="article-content">
-      <p>(<a href="https://www.patreon.com/db4s"><strong>Please</strong> consider sponsoring us on Patreon</a> 😄)</p>
+      <p>(<a href="https://www.patreon.com/db4s"><strong>Please</strong> consider sponsoring us on Patreon</a> &#x1f604;)</p>
 <h2 id="windows">Windows</h2>
 <p>Our latest release (3.12.2) for Windows:</p>
 <ul>
@@ -89,7 +90,7 @@
 </ul>
 <p><strong>Note</strong> - If for any reason the standard Windows release does not work
 (e.g. gives an error), try a nightly build (<a href="#nightly-builds">below</a>).</p>
-<p>Nightly builds often fix bugs reported after the last release. 😄</p>
+<p>Nightly builds often fix bugs reported after the last release. &#x1f604;</p>
 <h2 id="macos">macOS</h2>
 <p>Our latest release (3.12.2) for macOS:</p>
 <ul>
@@ -111,7 +112,7 @@
 <ul>
 <li><a href="https://download.sqlitebrowser.org/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage">DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage</a></li>
 </ul>
-<p>Remember to change it&rsquo;s permission bits to be executable before you run it. 😄</p>
+<p>Remember to change it&rsquo;s permission bits to be executable before you run it. &#x1f604;</p>
 <h3 id="snap-packages">Snap packages</h3>
 <p><a href="https://snapcraft.io/sqlitebrowser"><img src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" alt="Get it from the Snap Store"></a></p>
 <h4 id="snap-release-build">Snap Release build</h4>
@@ -185,7 +186,7 @@ Life</li>
 in <a href="https://github.com/sqlitebrowser/sqlitebrowser/blob/master/BUILDING.md#build-instructions-and-requirements">BUILDING.md</a>.</p>
 <h2 id="freebsd">FreeBSD</h2>
 <p>DB Browser for SQLite works well on FreeBSD, and there is a port for it (thanks
-to <a href="https://github.com/lbartoletti">lbartoletti</a> 😄).  DB4S can be installed
+to <a href="https://github.com/lbartoletti">lbartoletti</a> &#x1f604;).  DB4S can be installed
 using either this command:</p>
 <pre><code>make -C /usr/ports/databases/sqlitebrowser install
 </code></pre>
@@ -203,9 +204,9 @@ using either this command:</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>DB Browser for SQLite</title>
@@ -20,8 +20,7 @@
 
 
 
-
-<link href="/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -750,9 +749,9 @@ in order to achieve these goals.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -6,898 +6,630 @@
     <description>Recent content on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate><atom:link href="/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Support for SQLite extensions added</title>
       <link>/blog/support-for-sqlite-extensions-added/</link>
       <pubDate>Thu, 04 May 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/support-for-sqlite-extensions-added/</guid>
-      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:
-FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
+      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:&#xA;FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
     </item>
-    
     <item>
       <title>Live databases can be public .. and more updates</title>
       <link>/blog/live-databases-can-be-public/</link>
       <pubDate>Thu, 27 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-can-be-public/</guid>
-      <description>Another week, and another series of exciting updates to DBHub.io
-Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.
-Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.
-Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
+      <description>Another week, and another series of exciting updates to DBHub.io&#xA;Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.&#xA;Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.&#xA;Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
     </item>
-    
     <item>
       <title>Execute SQL Tab Overhaul</title>
       <link>/blog/execute-sql-tab-overhaul/</link>
       <pubDate>Wed, 26 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/execute-sql-tab-overhaul/</guid>
-      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.
-While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.
-&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;
-It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
+      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.&#xA;While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.&#xA;&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;&#xA;It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
     </item>
-    
     <item>
       <title>Comments now enabled on blog posts</title>
       <link>/blog/comments-now-enabled-on-blog-posts/</link>
       <pubDate>Mon, 24 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/comments-now-enabled-on-blog-posts/</guid>
-      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.
-We look forward to hearing from you!</description>
+      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.&#xA;We look forward to hearing from you!</description>
     </item>
-    
     <item>
       <title>More webUI related updates</title>
       <link>/blog/more-webui-related-updates/</link>
       <pubDate>Fri, 07 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/more-webui-related-updates/</guid>
-      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.
-Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data
-Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
+      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.&#xA;Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data&#xA;Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
     </item>
-    
     <item>
       <title>Database sharing has been improved on DBHub.io</title>
       <link>/blog/database-sharing-has-been-improved-on-dbhub-io/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/database-sharing-has-been-improved-on-dbhub-io/</guid>
-      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.
-DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
+      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.&#xA;DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
     </item>
-    
     <item>
       <title>Go Library (go-dbhub) updated to work with Live databases</title>
       <link>/blog/go-library-updated-to-work-with-live-databases/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/go-library-updated-to-work-with-live-databases/</guid>
-      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.
-You can see the initial blog post for the Go library here .</description>
+      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.&#xA;You can see the initial blog post for the Go library here .</description>
     </item>
-    
     <item>
       <title>Live databases are now .. live!</title>
       <link>/blog/live-databases-are-now-live/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-are-now-live/</guid>
-      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.
-One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
+      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.&#xA;One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
     </item>
-    
     <item>
       <title>Apple Silicon (M1/M2/etc) macOS package available</title>
       <link>/blog/apple-silicon-macos-package-available/</link>
       <pubDate>Mon, 24 Oct 2022 00:00:00 +0000</pubDate>
-      
       <guid>/blog/apple-silicon-macos-package-available/</guid>
-      <description>We are proud to present&amp;hellip; the Apple Silicon (arm64) version of DB Browser for SQLite v3.12.2:
-https://download.sqlitebrowser.org/DB.Browser.for.SQLite-arm64-3.12.2.dmg 0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8 (SHA256 checksum) If you&amp;rsquo;re using one of Apple&amp;rsquo;s M1 or M2 based macOS devices, then this native Apple Silicon version of DB4S should work a bit better than our existing Intel based download.
-Additionally, our nightly builds for macOS now have both Intel and Apple Silicon (arm64) downloads available:
-Nightly builds using SQLite (no encryption):</description>
+      <description>We are proud to present&amp;hellip; the Apple Silicon (arm64) version of DB Browser for SQLite v3.12.2:&#xA;https://download.sqlitebrowser.org/DB.Browser.for.SQLite-arm64-3.12.2.dmg 0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8 (SHA256 checksum) If you&amp;rsquo;re using one of Apple&amp;rsquo;s M1 or M2 based macOS devices, then this native Apple Silicon version of DB4S should work a bit better than our existing Intel based download.&#xA;Additionally, our nightly builds for macOS now have both Intel and Apple Silicon (arm64) downloads available:&#xA;Nightly builds using SQLite (no encryption):</description>
     </item>
-    
     <item>
       <title>Huge thanks to DigitalOcean for sponsoring us!</title>
       <link>/blog/huge-thanks-to-digitalocean/</link>
       <pubDate>Sun, 25 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/huge-thanks-to-digitalocean/</guid>
-      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! 🕺
-We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!
-If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. 😄</description>
+      <description>A huge shout out and thanks to DigitalOcean for hosting our entire Infrastructure, 100% free! &amp;#x1f57a;&#xA;We&amp;rsquo;ve been with them for over a year now, and have a bunch of servers. In that time, we&amp;rsquo;ve experienced no outages or weirdness whatsoever. It&amp;rsquo;s been fantastic!&#xA;If you&amp;rsquo;re looking for a good, reliable Cloud service that doesn&amp;rsquo;t suffer from network weirdness or outages, DigitalOcean is a solid choice. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Linux AppImage of 3.12.2 release available</title>
       <link>/blog/linux-appimage-available/</link>
       <pubDate>Sat, 10 Jul 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/linux-appimage-available/</guid>
-      <description>Thanks to new team member Nikolay Zlatev, an AppImage of our recent 3.12.2 release is available:
-https://download.sqlitebrowser.org/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage ea14c7439f7e666f3e9d8cbffe9048134b87db3e2d7bf65f4146b0649536de5c (SHA256 checksum) That should work on most Linux (x86_64) distributions, and should help people running older software to use our new releases.
-Good stuff Nikolay! 😀</description>
+      <description>Thanks to new team member Nikolay Zlatev, an AppImage of our recent 3.12.2 release is available:&#xA;https://download.sqlitebrowser.org/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage ea14c7439f7e666f3e9d8cbffe9048134b87db3e2d7bf65f4146b0649536de5c (SHA256 checksum) That should work on most Linux (x86_64) distributions, and should help people running older software to use our new releases.&#xA;Good stuff Nikolay! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>First release of Python library &#39;pydbhub&#39;</title>
       <link>/blog/first-release-pydbhub/</link>
       <pubDate>Sat, 05 Jun 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-pydbhub/</guid>
-      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. 😄
-It&amp;rsquo;s called pydbhub, and is available here:
-https://github.com/LeMoussel/pydbhub
-And on PyPi:
-https://pypi.org/project/pydbhub/</description>
+      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. &amp;#x1f604;&#xA;It&amp;rsquo;s called pydbhub, and is available here:&#xA;https://github.com/LeMoussel/pydbhub&#xA;And on PyPi:&#xA;https://pypi.org/project/pydbhub/</description>
     </item>
-    
     <item>
       <title>Version 3.12.2 released</title>
       <link>/blog/version-3-12-2-released/</link>
       <pubDate>Tue, 18 May 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-2-released/</guid>
-      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.
-You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. 😄
-The changes in this over the 3.12.1 release include:
-Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
+      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.&#xA;You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. &amp;#x1f604;&#xA;The changes in this over the 3.12.1 release include:&#xA;Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
     </item>
-    
     <item>
       <title>Thanks to our Patreon supporters, we have a HiDPI monitor!</title>
       <link>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</link>
       <pubDate>Sat, 06 Mar 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</guid>
-      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.
-A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.
-This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
+      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.&#xA;A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.&#xA;This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
     </item>
-    
     <item>
       <title>Version 3.12.1 released</title>
       <link>/blog/version-3-12-1-released/</link>
       <pubDate>Mon, 09 Nov 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-1-released/</guid>
-      <description>This is the first bug fix release for our 3.12.x series.
-There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. 😄
-Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
+      <description>This is the first bug fix release for our 3.12.x series.&#xA;There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. &amp;#x1f604;&#xA;Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.1</title>
       <link>/blog/first-release-candidate-for-3-12-1/</link>
       <pubDate>Sun, 27 Sep 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-1/</guid>
-      <description>This is the first, and hopefully only 😉, release candidate for DB Browser for SQLite version 3.12.1.
-Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:
-Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
+      <description>This is the first, and hopefully only &amp;#x1f609;, release candidate for DB Browser for SQLite version 3.12.1.&#xA;Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:&#xA;Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
     </item>
-    
     <item>
       <title>New Go library for working with your DBHub.io databases</title>
       <link>/blog/new-go-library-for-working-with-your-dbhub-io-databases/</link>
       <pubDate>Sat, 01 Aug 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-go-library-for-working-with-your-dbhub-io-databases/</guid>
-      <description>For anyone with an interest in Go programming, there&amp;rsquo;s now a library to access and query your databases on DBHub.io:
-https://github.com/sqlitebrowser/go-dbhub
-Documentation is in place, code quality is good, and there are worked examples for each function call.
-It&amp;rsquo;s still in early stages of development, but seems to work well already. 😄
-What works now Run read-only queries (eg SELECT statements) on databases, returning the results as JSON List the tables, views, and indexes present in a database List the columns in a table, view or index, along with their details (Added 2020-08-02) - Generate a diff between two databases or revisions, to transform one into the other (Added 2020-08-04) - List the branches of a database (Added 2020-08-04) - Download a complete database (Added 2020-08-05) - List the databases in your account (Added 2020-08-05) - Download the database metadata (branches, releases, tags, commits, etc) Still to do Tests for each function Upload a complete database Investigate what would be needed for this to work through the Go SQL API Anything else that people suggest and seems like a good idea 😄 Requirements Go version 1.</description>
+      <description>For anyone with an interest in Go programming, there&amp;rsquo;s now a library to access and query your databases on DBHub.io:&#xA;https://github.com/sqlitebrowser/go-dbhub&#xA;Documentation is in place, code quality is good, and there are worked examples for each function call.&#xA;It&amp;rsquo;s still in early stages of development, but seems to work well already. &amp;#x1f604;&#xA;What works now Run read-only queries (eg SELECT statements) on databases, returning the results as JSON List the tables, views, and indexes present in a database List the columns in a table, view or index, along with their details (Added 2020-08-02) - Generate a diff between two databases or revisions, to transform one into the other (Added 2020-08-04) - List the branches of a database (Added 2020-08-04) - Download a complete database (Added 2020-08-05) - List the databases in your account (Added 2020-08-05) - Download the database metadata (branches, releases, tags, commits, etc) Still to do Tests for each function Upload a complete database Investigate what would be needed for this to work through the Go SQL API Anything else that people suggest and seems like a good idea &amp;#x1f604; Requirements Go version 1.</description>
     </item>
-    
     <item>
       <title>New API for remotely executing SQLite queries</title>
       <link>/blog/new-api-for-remotely-executing-sqlite-queries/</link>
       <pubDate>Sun, 19 Jul 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-api-for-remotely-executing-sqlite-queries/</guid>
-      <description>For anyone wanting to run SQL queries against their uploaded databases, there&amp;rsquo;s now an API server: https://api.dbhub.io
-As a starting point, there&amp;rsquo;s just one API call (/v1/query), and it only runs SELECT queries (eg read only database). That should be useful enough for many things though.
-Query parameters Query parameters are passed via POST only, and all results are in a fairly verbose JSON format.
-apikey - Your API key. These can be generated in your Settings page, when logged in to DBHub.</description>
+      <description>For anyone wanting to run SQL queries against their uploaded databases, there&amp;rsquo;s now an API server: https://api.dbhub.io&#xA;As a starting point, there&amp;rsquo;s just one API call (/v1/query), and it only runs SELECT queries (eg read only database). That should be useful enough for many things though.&#xA;Query parameters Query parameters are passed via POST only, and all results are in a fairly verbose JSON format.&#xA;apikey - Your API key. These can be generated in your Settings page, when logged in to DBHub.</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.12.0 release now available</title>
       <link>/blog/portableapp-for-3-12-0-release-now-available/</link>
       <pubDate>Thu, 18 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-12-0-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
     </item>
-    
     <item>
       <title>Version 3.12.0 released</title>
       <link>/blog/version-3-12-0-released/</link>
       <pubDate>Tue, 16 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-0-released/</guid>
       <description>Downloads DB.Browser.for.SQLite-3.12.0-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-win64.zip - .zip (no installer) for 64-bit Windows SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe - PortableApp for Windows DB.Browser.for.SQLite-3.12.0.dmg - Standard package for macOS Highlights Better table editing SQLite 3.25.0 added support for renaming columns with the ALTER TABLE command (previously you had to create a new table with the renamed column, copy all data over, delete the old table, then rename the new table - even leaving out some details of the process here&amp;hellip;).</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.0</title>
       <link>/blog/first-release-candidate-for-3-12-0/</link>
       <pubDate>Mon, 08 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-0/</guid>
-      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.
-Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
+      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.12.0</title>
       <link>/blog/first-alpha-release-for-3-12-0/</link>
       <pubDate>Wed, 15 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-12-0/</guid>
-      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.
-Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
+      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
     </item>
-    
     <item>
       <title>Adding basic visualisation capability to dbhub.io</title>
       <link>/blog/adding-basic-visualisation-capability-to-dbhub-io/</link>
       <pubDate>Wed, 08 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/adding-basic-visualisation-capability-to-dbhub-io/</guid>
-      <description>We&amp;rsquo;ve begun adding the first visualisation pieces to DBHub.io, so people can display charts from their data.
-eg:
-This is only the starting point (eg a simple vertical bar chart) while we experiment, to find a good workflow that&amp;rsquo;s easy for people to use + customise.
-We&amp;rsquo;re aiming to add several more chart types to choose from, and there being a selection of easy-to-use predefined templates as well.
-Advanced users will ideally be able to input their own SQL queries for generating the data points to visualise.</description>
+      <description>We&amp;rsquo;ve begun adding the first visualisation pieces to DBHub.io, so people can display charts from their data.&#xA;eg:&#xA;This is only the starting point (eg a simple vertical bar chart) while we experiment, to find a good workflow that&amp;rsquo;s easy for people to use + customise.&#xA;We&amp;rsquo;re aiming to add several more chart types to choose from, and there being a selection of easy-to-use predefined templates as well.&#xA;Advanced users will ideally be able to input their own SQL queries for generating the data points to visualise.</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.11.2 release now available</title>
       <link>/blog/portableapp-for-3-11-2-release-now-available/</link>
       <pubDate>Tue, 07 May 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-11-2-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
     </item>
-    
     <item>
       <title>New landing page for DBHub.io</title>
       <link>/blog/new-landing-page-for-dbhub-io/</link>
       <pubDate>Fri, 26 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-landing-page-for-dbhub-io/</guid>
-      <description>Our sister website, DBHub.io - where people can backup their databases, share them with others, and collaboratively develop data - has a proper landing page from today:
-https://dbhub.io
-It required quite a lot of effort to assemble, even though it&amp;rsquo;s just a simple description, screenshots (click them!), and an overview video. 😉
-Please take a look, create an account (it&amp;rsquo;s free), and try things out.
-The website code is fully Open Source, and is gaining interesting + useful capabilities over time.</description>
+      <description>Our sister website, DBHub.io - where people can backup their databases, share them with others, and collaboratively develop data - has a proper landing page from today:&#xA;https://dbhub.io&#xA;It required quite a lot of effort to assemble, even though it&amp;rsquo;s just a simple description, screenshots (click them!), and an overview video. &amp;#x1f609;&#xA;Please take a look, create an account (it&amp;rsquo;s free), and try things out.&#xA;The website code is fully Open Source, and is gaining interesting + useful capabilities over time.</description>
     </item>
-    
     <item>
       <title>Standard username/password logins now working for DBHub.io</title>
       <link>/blog/standard-username-password-logins-now-working-for-dbhub-io/</link>
       <pubDate>Wed, 10 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/standard-username-password-logins-now-working-for-dbhub-io/</guid>
-      <description>A small, but important, update about DBHub.io logins. 😉
-People can now create accounts using their own username/password again, instead of needing to login via GitHub, Google, or LinkedIn.
-It used to work (ages ago), but Auth0 found a security problem with the version of NodeJS they were using, so disabled it for everyone last year. It was fixable by changing some stuff, which has now been done.
-On a related note&amp;hellip; login (using username/password) only works if &amp;ldquo;3rd party cookies&amp;rdquo; aren&amp;rsquo;t blocked in your web browser.</description>
+      <description>A small, but important, update about DBHub.io logins. &amp;#x1f609;&#xA;People can now create accounts using their own username/password again, instead of needing to login via GitHub, Google, or LinkedIn.&#xA;It used to work (ages ago), but Auth0 found a security problem with the version of NodeJS they were using, so disabled it for everyone last year. It was fixable by changing some stuff, which has now been done.&#xA;On a related note&amp;hellip; login (using username/password) only works if &amp;ldquo;3rd party cookies&amp;rdquo; aren&amp;rsquo;t blocked in your web browser.</description>
     </item>
-    
     <item>
       <title>New download and daily users stats page</title>
       <link>/blog/new-download-daily-users-stats-page/</link>
       <pubDate>Tue, 09 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-download-daily-users-stats-page/</guid>
-      <description>Today we added a new &amp;ldquo;Stats&amp;rdquo; page, showing the number of daily downloads and daily users:
-https://sqlitebrowser.org/stats/
-The graphs are generated using Redash, and should automatically update every 10 minutes:
-https://redash.io
-Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite 😉).
-It&amp;rsquo;s running in a very low end virtual machine (eg cheap), and there&amp;rsquo;s no proper caching layer yet, so it may be a bit slow to load.</description>
+      <description>Today we added a new &amp;ldquo;Stats&amp;rdquo; page, showing the number of daily downloads and daily users:&#xA;https://sqlitebrowser.org/stats/&#xA;The graphs are generated using Redash, and should automatically update every 10 minutes:&#xA;https://redash.io&#xA;Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite &amp;#x1f609;).&#xA;It&amp;rsquo;s running in a very low end virtual machine (eg cheap), and there&amp;rsquo;s no proper caching layer yet, so it may be a bit slow to load.</description>
     </item>
-    
     <item>
       <title>Statistics</title>
       <link>/stats/</link>
       <pubDate>Mon, 08 Apr 2019 22:43:15 +1100</pubDate>
-      
       <guid>/stats/</guid>
-      <description>Note - The data behind these graphs (created using Redash) automatically updates every 10 minutes.
-Monthly downloads These Monthly Download stats begin in August 2018, when we moved our primary download location from GitHub to our own infrastructure.
-GitHub does make download stats available through their API, and it would be useful to add the historical (and ongoing) downloads from GitHub to this too.
-There&amp;rsquo;s about 1/2 million downloads of our 3.</description>
+      <description>Note - The data behind these graphs (created using Redash) automatically updates every 10 minutes.&#xA;Monthly downloads These Monthly Download stats begin in August 2018, when we moved our primary download location from GitHub to our own infrastructure.&#xA;GitHub does make download stats available through their API, and it would be useful to add the historical (and ongoing) downloads from GitHub to this too.&#xA;There&amp;rsquo;s about 1/2 million downloads of our 3.</description>
     </item>
-    
     <item>
       <title>Version 3.11.2 released</title>
       <link>/blog/version-3-11-2-released/</link>
       <pubDate>Thu, 04 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-2-released/</guid>
-      <description>This is a minor bug fix release in the 3.11.x series
-Bug fixes and enhancements since 3.11.1 Enable &amp;lsquo;Edit Database Cell&amp;rsquo; when view is editable (#1756) DB browser crashes when I try to attach additional database to current one (#1758) CASE-SENSITIVITY: Error importing data from SQL file: cannot start a transaction within a transaction (#1764) Cell edit window considers binary data to be text/numeric if first byte is in ascii range (#1772) Crashes when browsing a empty view with view editing enabled (#1774) Trying to save after successfull import fails (#1777) Attach encrypted database results in Out of Memory Error (#1799) File is not a database (#1814) Can&amp;rsquo;t remove password from an encrypted database any more (#1829) grammar: Fix keywords as table name and keywords as column name (1a59c8cbda47684dfc0b55283fc6fdb396adc832) Updated translation strings Korean (#1600) Brazilian Portuguese (#1830) Italian (#1833) German (e2ad5459d569801f9a635391f774e81ca1009e85) Include SQLite 3.</description>
+      <description>This is a minor bug fix release in the 3.11.x series&#xA;Bug fixes and enhancements since 3.11.1 Enable &amp;lsquo;Edit Database Cell&amp;rsquo; when view is editable (#1756) DB browser crashes when I try to attach additional database to current one (#1758) CASE-SENSITIVITY: Error importing data from SQL file: cannot start a transaction within a transaction (#1764) Cell edit window considers binary data to be text/numeric if first byte is in ascii range (#1772) Crashes when browsing a empty view with view editing enabled (#1774) Trying to save after successfull import fails (#1777) Attach encrypted database results in Out of Memory Error (#1799) File is not a database (#1814) Can&amp;rsquo;t remove password from an encrypted database any more (#1829) grammar: Fix keywords as table name and keywords as column name (1a59c8cbda47684dfc0b55283fc6fdb396adc832) Updated translation strings Korean (#1600) Brazilian Portuguese (#1830) Italian (#1833) German (e2ad5459d569801f9a635391f774e81ca1009e85) Include SQLite 3.</description>
     </item>
-    
     <item>
       <title>Dark theme support in our nightly builds</title>
       <link>/blog/dark-theme-support-in-our-nightly-builds/</link>
       <pubDate>Sat, 02 Mar 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/dark-theme-support-in-our-nightly-builds/</guid>
-      <description>Thanks to the dedicated efforts of @mgrojo, our nightly builds now include a &amp;ldquo;Dark style&amp;rdquo; theme courtesy of the QDarkStyleSheet project:
-To activate it, choose &amp;ldquo;Dark style&amp;rdquo; from the &amp;ldquo;Application Style&amp;rdquo; dropdown in Preferences→General:
-To turn it off, choose &amp;ldquo;Follow the desktop style&amp;rdquo; instead.
-The nightly builds for windows and macOS are here:
-https://nightlies.sqlitebrowser.org/latest/
-The nightly builds for Ubuntu Linux are here:
-https://sqlitebrowser.org/dl/#nightly-builds-1</description>
+      <description>Thanks to the dedicated efforts of @mgrojo, our nightly builds now include a &amp;ldquo;Dark style&amp;rdquo; theme courtesy of the QDarkStyleSheet project:&#xA;To activate it, choose &amp;ldquo;Dark style&amp;rdquo; from the &amp;ldquo;Application Style&amp;rdquo; dropdown in Preferences→General:&#xA;To turn it off, choose &amp;ldquo;Follow the desktop style&amp;rdquo; instead.&#xA;The nightly builds for windows and macOS are here:&#xA;https://nightlies.sqlitebrowser.org/latest/&#xA;The nightly builds for Ubuntu Linux are here:&#xA;https://sqlitebrowser.org/dl/#nightly-builds-1</description>
     </item>
-    
     <item>
       <title>macOS installer rebuilt for 3.11.1</title>
       <link>/blog/macos-installer-rebuilt-for-3-11-1/</link>
       <pubDate>Sat, 23 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/macos-installer-rebuilt-for-3-11-1/</guid>
-      <description>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &amp;ldquo;light theme mode&amp;rdquo; (the Aqua look) on macOS Mojave. 😄
-https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg
-It&amp;rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&amp;rsquo;t yet properly support. Without this workaround, the colour pallete was unusable in important places. eg white on white when browsing data 😦
-Jesse Jackson, thank you so much for showing us how to fix this problem.</description>
+      <description>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &amp;ldquo;light theme mode&amp;rdquo; (the Aqua look) on macOS Mojave. &amp;#x1f604;&#xA;https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg&#xA;It&amp;rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&amp;rsquo;t yet properly support. Without this workaround, the colour pallete was unusable in important places. eg white on white when browsing data &amp;#x1f626;&#xA;Jesse Jackson, thank you so much for showing us how to fix this problem.</description>
     </item>
-    
     <item>
       <title>Version 3.11.1 released</title>
       <link>/blog/version-3-11-1-released/</link>
       <pubDate>Mon, 18 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-1-released/</guid>
-      <description>Note that this is effectively 3.11.0 from last week, with a critical bug fix on top + some other additional fixes.
-Note 2 - If you&amp;rsquo;re using Dark Mode on macOS Mojave, Do Not download this release. Dark Mode support is broken (badly) on MacOS. It should (hopefully) be fixed in the next point release.
-Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support on Linux Dark mode support for windows and macOS isn&amp;rsquo;t working yet.</description>
+      <description>Note that this is effectively 3.11.0 from last week, with a critical bug fix on top + some other additional fixes.&#xA;Note 2 - If you&amp;rsquo;re using Dark Mode on macOS Mojave, Do Not download this release. Dark Mode support is broken (badly) on MacOS. It should (hopefully) be fixed in the next point release.&#xA;Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support on Linux Dark mode support for windows and macOS isn&amp;rsquo;t working yet.</description>
     </item>
-    
     <item>
       <title>Version 3.11.0 pulled - encrypting databases non-functional</title>
       <link>/blog/version-3-11-0-pulled/</link>
       <pubDate>Mon, 11 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-0-pulled/</guid>
-      <description>A serious bug has been found in the recent 3.11.0 release&amp;hellip; newly encrypting databases doesn&amp;rsquo;t work (#1732), instead displaying an error message. 😦
-Existing databases - encrypted or not - can be opened without problem. The problem only occurs when attempting to newly encrypt a database.
-The links on our download page have been reverted back to the prior stable release (3.10.1) for now, while we look into this.
-There will probably be a 3.</description>
+      <description>A serious bug has been found in the recent 3.11.0 release&amp;hellip; newly encrypting databases doesn&amp;rsquo;t work (#1732), instead displaying an error message. &amp;#x1f626;&#xA;Existing databases - encrypted or not - can be opened without problem. The problem only occurs when attempting to newly encrypt a database.&#xA;The links on our download page have been reverted back to the prior stable release (3.10.1) for now, while we look into this.&#xA;There will probably be a 3.</description>
     </item>
-    
     <item>
       <title>Added public web stats using Fathom</title>
       <link>/blog/added-public-web-stats-using-fathom/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-public-web-stats-using-fathom/</guid>
-      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.
-The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.
-PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
+      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.&#xA;The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.&#xA;PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
     </item>
-    
     <item>
       <title>Version 3.11.0 released</title>
       <link>/blog/version-3-11-0-released/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-0-released/</guid>
       <description>Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support Multi-threaded loading of data Default quotes changed to double quotes Add Record dialog Printing support The math extensions for SQLite are included in the windows and macOS installers @SilvioGrosso has kindly created a video showing how to load the math extensions on windows Downloads DB.</description>
     </item>
-    
     <item>
       <title>Updated our website!</title>
       <link>/blog/new-website/</link>
       <pubDate>Thu, 31 Jan 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-website/</guid>
-      <description>Experimenting with a new approach for the DB Browser for SQLite website, as the old 1-page website was difficult to expand with blog/info on what we&amp;rsquo;ve been working on.
-This new layout - using Hugo and blogdown - should be a decent foundation, and is fairly customisable.
-It also has many available themes, which we&amp;rsquo;ll likely experiment with too.</description>
+      <description>Experimenting with a new approach for the DB Browser for SQLite website, as the old 1-page website was difficult to expand with blog/info on what we&amp;rsquo;ve been working on.&#xA;This new layout - using Hugo and blogdown - should be a decent foundation, and is fairly customisable.&#xA;It also has many available themes, which we&amp;rsquo;ll likely experiment with too.</description>
     </item>
-    
     <item>
       <title>About</title>
       <link>/about/</link>
       <pubDate>Wed, 30 Jan 2019 14:09:28 +1100</pubDate>
-      
       <guid>/about/</guid>
-      <description>This program was developed originally by Mauricio Piacentini (@piacentini) from Tabuleiro Producoes, as the Arca Database Browser. The original version was used as a free companion tool to the Arca Database Xtra, a commercial product that embeds SQLite databases with some additional extensions to handle compressed and binary data.
-The original code was trimmed and adjusted to be compatible with standard SQLite 2.x databases. The resulting program was renamed SQLite Database Browser, and released into the Public Domain by Mauricio.</description>
+      <description>This program was developed originally by Mauricio Piacentini (@piacentini) from Tabuleiro Producoes, as the Arca Database Browser. The original version was used as a free companion tool to the Arca Database Xtra, a commercial product that embeds SQLite databases with some additional extensions to handle compressed and binary data.&#xA;The original code was trimmed and adjusted to be compatible with standard SQLite 2.x databases. The resulting program was renamed SQLite Database Browser, and released into the Public Domain by Mauricio.</description>
     </item>
-    
     <item>
       <title>Third beta release of 3.11.0</title>
       <link>/blog/third-beta-release-of-3-11-0y/</link>
       <pubDate>Thu, 13 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/third-beta-release-of-3-11-0y/</guid>
       <description>The third beta builds for our next major release are ready for testing. Please try them out, and report any weirdness.</description>
     </item>
-    
     <item>
       <title>Second beta release of 3.11.0</title>
       <link>/blog/second-beta-release-of-3-11-0/</link>
       <pubDate>Wed, 12 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-of-3-11-0/</guid>
       <description>The second beta builds for our next major release are ready.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.11.0</title>
       <link>/blog/first-beta-release-of-3-11-0/</link>
       <pubDate>Tue, 27 Nov 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-11-0/</guid>
       <description>The first beta builds for our next major release are ready for testing.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.11.0</title>
       <link>/blog/first-alpha-release-for-3-11-0/</link>
       <pubDate>Wed, 10 Oct 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-11-0/</guid>
       <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.</description>
     </item>
-    
     <item>
       <title>New download servers</title>
       <link>/blog/new-download-servers/</link>
       <pubDate>Thu, 09 Aug 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-download-servers/</guid>
       <description>We&amp;rsquo;ve just started testing a new download server cluster. If anything seems weird with our downloads, please report it here.</description>
     </item>
-    
     <item>
       <title>Patreon account created</title>
       <link>/blog/patreon-account-created/</link>
       <pubDate>Fri, 08 Jun 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/patreon-account-created/</guid>
-      <description>We&amp;rsquo;ve just created a Patreon account. Please become a Patron of DB Browser for SQLite! 😄</description>
+      <description>We&amp;rsquo;ve just created a Patreon account. Please become a Patron of DB Browser for SQLite! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Windows MSI installers now available</title>
       <link>/blog/windows-msi-installers-now-available/</link>
       <pubDate>Sat, 02 Jun 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/windows-msi-installers-now-available/</guid>
       <description>Windows MSI installers are now available on our nightly build server!</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.10.1</title>
       <link>/blog/portableapp-version-of-3-10-1/</link>
       <pubDate>Thu, 28 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-10-1/</guid>
-      <description>Added PortableApp version of 3.10.1. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.10.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.10.1 released</title>
       <link>/blog/version-3-10-1-released/</link>
       <pubDate>Wed, 20 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-10-1-released/</guid>
       <description>DB Browser for SQLite 3.10.1 has been released! :D</description>
     </item>
-    
     <item>
       <title>Removed continuous AppImage builds for Linux</title>
       <link>/blog/removed-continuous-appimage-builds-for-linux/</link>
       <pubDate>Fri, 08 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/removed-continuous-appimage-builds-for-linux/</guid>
       <description>Removed the continuous AppImage builds for Linux due to problems with the upload script.</description>
     </item>
-    
     <item>
       <title>AppImage builds for Linux</title>
       <link>/blog/appimage-builds-for-linux/</link>
       <pubDate>Sat, 02 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/appimage-builds-for-linux/</guid>
       <description>AppImage builds for Linux - always built from the latest DB4S commit - are now online.</description>
     </item>
-    
     <item>
       <title>Version 3.10.0 released</title>
       <link>/blog/version-3-10-0-released/</link>
       <pubDate>Sun, 20 Aug 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-10-0-released/</guid>
-      <description>DB Browser for SQLite 3.10.0 has been released! Yay! 😀</description>
+      <description>DB Browser for SQLite 3.10.0 has been released! Yay! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>Second beta release for 3.10.0</title>
       <link>/blog/second-beta-release-for-3-10-0/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-for-3-10-0/</guid>
       <description>The second beta release for our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
     <item>
       <title>First (beta) DBHub.io server with DB4S integration is online</title>
       <link>/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/</link>
       <pubDate>Sat, 29 Jul 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/</guid>
-      <description>The first &amp;ldquo;db4s-beta&amp;rdquo; server is now online, which DB4S 3.10.0-beta can store/retrieve databases in.
-Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). 😄 Don&amp;rsquo;t store important data in it yet though, as we don&amp;rsquo;t have backups set up yet.</description>
+      <description>The first &amp;ldquo;db4s-beta&amp;rdquo; server is now online, which DB4S 3.10.0-beta can store/retrieve databases in.&#xA;Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). :smile: Don&amp;rsquo;t store important data in it yet though, as we don&amp;rsquo;t have backups set up yet.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.10.0</title>
       <link>/blog/first-beta-release-of-3-10-0/</link>
       <pubDate>Fri, 21 Jul 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-10-0/</guid>
       <description>The first beta release of our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
     <item>
       <title>Nightly builds now using static URLs</title>
       <link>/blog/nightly-builds-now-using-static-urls/</link>
       <pubDate>Wed, 17 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/nightly-builds-now-using-static-urls/</guid>
       <description>Our latest nightly builds now use static URLs. Useful for bookmarking and automation.</description>
     </item>
-    
     <item>
       <title>WinXP version for 3.9.1</title>
       <link>/blog/winxp-version-for-3-9-1/</link>
       <pubDate>Sun, 14 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/winxp-version-for-3-9-1/</guid>
       <description>Due to popular demand, there is now a Windows XP compatible download.</description>
     </item>
-    
     <item>
       <title>Rebuilt OSX binary for v3.9.1</title>
       <link>/blog/rebuilt-osx-binary-for-v3-9-1/</link>
       <pubDate>Sat, 17 Dec 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/rebuilt-osx-binary-for-v3-9-1/</guid>
       <description>The v3.9.1 binary for OSX has been rebuilt using Qt 5.7.1, to fix an important colour display problem on macOS Sierra.</description>
     </item>
-    
     <item>
       <title>Initial DBHub.io server online</title>
       <link>/blog/initial-dbhub-io-server-online/</link>
       <pubDate>Thu, 15 Dec 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/initial-dbhub-io-server-online/</guid>
-      <description>An initial DBHub.io server is online, running our latest development code. Testing and feedback is encouraged.
-Note - The data on this server will probably be wiped/reset every few days.</description>
+      <description>An initial DBHub.io server is online, running our latest development code. Testing and feedback is encouraged.&#xA;Note - The data on this server will probably be wiped/reset every few days.</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.9.1</title>
       <link>/blog/portableapp-for-3-9-1/</link>
       <pubDate>Thu, 20 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-9-1/</guid>
-      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! 😄</description>
+      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>New Qt5 based nightly builds online</title>
       <link>/blog/new-qt5-based-nightly-builds-online/</link>
       <pubDate>Mon, 17 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-qt5-based-nightly-builds-online/</guid>
       <description>New Qt5 based nightly builds are online.</description>
     </item>
-    
     <item>
       <title>Version 3.9.1 released</title>
       <link>/blog/version-3-9-1-released/</link>
       <pubDate>Mon, 03 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-1-released/</guid>
       <description>Version 3.9.1 released. Mostly bug fixes.</description>
     </item>
-    
     <item>
       <title>New sister project: DBHub.io</title>
       <link>/blog/new-sister-project-dbhub-io/</link>
       <pubDate>Mon, 26 Sep 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-sister-project-dbhub-io/</guid>
-      <description>Added first page for our new sister project: DBHub.io. Take a look! 😄</description>
+      <description>Added first page for our new sister project: DBHub.io. Take a look! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.9.0</title>
       <link>/blog/portableapp-version-of-3-9-0/</link>
       <pubDate>Thu, 08 Sep 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-9-0/</guid>
-      <description>Added PortableApp download for version 3.9.0. Thanks John! 😄</description>
+      <description>Added PortableApp download for version 3.9.0. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.9.0 released</title>
       <link>/blog/version-3-9-0-released/</link>
       <pubDate>Wed, 24 Aug 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-0-released/</guid>
       <description>The next major release, version 3.9.0 is ready for download!</description>
     </item>
-    
     <item>
       <title>Version 3.9.0 beta1 released</title>
       <link>/blog/version-3-9-0-beta1-released/</link>
       <pubDate>Sun, 14 Aug 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-0-beta1-released/</guid>
-      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.
-[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. 😄</description>
+      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.&#xA;[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. :smile:</description>
     </item>
-    
     <item>
       <title>Test build with SQLCipher for Win64</title>
       <link>/blog/test-build-with-sqlcipher-for-win64/</link>
       <pubDate>Wed, 04 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/test-build-with-sqlcipher-for-win64/</guid>
-      <description>Added an initial test build with encryption support on 64-bit Windows. Give it a go! 😀</description>
+      <description>Added an initial test build with encryption support on 64-bit Windows. Give it a go! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>Added 64-bit Windows development instructions to the wiki</title>
       <link>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</link>
       <pubDate>Mon, 02 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</guid>
       <description>Added full 64-bit Windows development instructions to the wiki, with many screenshots.</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.8.0</title>
       <link>/blog/portableapp-version-of-3-8-0/</link>
       <pubDate>Sun, 17 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-8-0/</guid>
-      <description>Added PortableApp version of 3.8.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.8.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>New 3.8.0 downloads for MacOS X</title>
       <link>/blog/new-3-8-0-downloads-for-macos-x/</link>
       <pubDate>Wed, 06 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-3-8-0-downloads-for-macos-x/</guid>
       <description>New 3.8.0 downloads for MacOS X today, to fix a crashing bug.</description>
     </item>
-    
     <item>
       <title>Fixed the downloads for v3.8.0</title>
       <link>/blog/fixed-the-downloads-for-v3-8-0/</link>
       <pubDate>Sat, 26 Dec 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/fixed-the-downloads-for-v3-8-0/</guid>
       <description>New (fixed) downloads for version 3.8.0 are available!</description>
     </item>
-    
     <item>
       <title>Version 3.8.0 released</title>
       <link>/blog/version-3-8-0-released/</link>
       <pubDate>Fri, 25 Dec 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-8-0-released/</guid>
-      <description>Version 3.8.0 released!
-Buggy release, removed for now. Keep using 3.7.0.</description>
+      <description>Version 3.8.0 released!&#xA;Buggy release, removed for now. Keep using 3.7.0.</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.7.0</title>
       <link>/blog/portableapp-version-of-3-7-0/</link>
       <pubDate>Tue, 07 Jul 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-7-0/</guid>
-      <description>Added PortableApp version of 3.7.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.7.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.7.0 released</title>
       <link>/blog/version-3-7-0-released/</link>
       <pubDate>Sun, 14 Jun 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-7-0-released/</guid>
-      <description>Version 3.7.0 released. 😄</description>
+      <description>Version 3.7.0 released. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.6.0v3</title>
       <link>/blog/portableapp-version-of-3-6-0v3/</link>
       <pubDate>Sat, 09 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-6-0v3/</guid>
-      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. 😄</description>
+      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Windows XP support added back</title>
       <link>/blog/windows-xp-support-added-back/</link>
       <pubDate>Tue, 05 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/windows-xp-support-added-back/</guid>
-      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. 😉</description>
+      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. &amp;#x1f609;</description>
     </item>
-    
     <item>
       <title>Fixed windows installer for 3.6.0</title>
       <link>/blog/fixed-windows-installer-for-3-6-0/</link>
       <pubDate>Wed, 29 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/fixed-windows-installer-for-3-6-0/</guid>
       <description>The Windows installer for v3.6.0 has been fixed (was missing .dlls).</description>
     </item>
-    
     <item>
       <title>Problems with the windows installer for 3.6.0</title>
       <link>/blog/problems-with-the-windows-installer-for-3-6-0/</link>
       <pubDate>Tue, 28 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/problems-with-the-windows-installer-for-3-6-0/</guid>
       <description>Problems with the windows installer for 3.6.0. Took those down for today.</description>
     </item>
-    
     <item>
       <title>Version 3.6.0 released</title>
       <link>/blog/version-3-6-0-released/</link>
       <pubDate>Mon, 27 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-6-0-released/</guid>
       <description>Version 3.6.0 released. Lots of enhancements over all previous releases. You want this!</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.5.1</title>
       <link>/blog/portableapp-version-of-3-5-1/</link>
       <pubDate>Tue, 17 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-5-1/</guid>
-      <description>Added PortableApp download for v3.5.1. Thanks John. 😄</description>
+      <description>Added PortableApp download for v3.5.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.5.1 released</title>
       <link>/blog/version-3-5-1-released/</link>
       <pubDate>Sun, 08 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-5-1-released/</guid>
-      <description>Version 3.5.1 released. Fixes bugs in 3.5.0. 😄</description>
+      <description>Version 3.5.1 released. Fixes bugs in 3.5.0. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.5.0 released</title>
       <link>/blog/version-3-5-0-released/</link>
       <pubDate>Sat, 31 Jan 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-5-0-released/</guid>
       <description>Version 3.5.0 released. Adds optional SQLCipher support for MacOS X and Linux.</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.4.0</title>
       <link>/blog/portableapp-version-of-3-4-0/</link>
       <pubDate>Thu, 29 Jan 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-4-0/</guid>
       <description>Added PortableApp download for v3.4.0.</description>
     </item>
-    
     <item>
       <title>Version 3.4.0 released</title>
       <link>/blog/version-3-4-0-released/</link>
       <pubDate>Wed, 29 Oct 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-4-0-released/</guid>
       <description>Version 3.4.0 released. Huge improvements in .csv handling and other tweaks.</description>
     </item>
-    
     <item>
       <title>Project renamed... (again)</title>
       <link>/blog/project-renamed-again/</link>
       <pubDate>Tue, 23 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/project-renamed-again/</guid>
-      <description>It turned out our previous &amp;ldquo;new&amp;rdquo; project name was already taken. Oops.
-So, our project has now been renamed to &amp;ldquo;DB Browser for SQLite&amp;rdquo;.
-Hopefully this is the final rename. 😄</description>
+      <description>It turned out our previous &amp;ldquo;new&amp;rdquo; project name was already taken. Oops.&#xA;So, our project has now been renamed to &amp;ldquo;DB Browser for SQLite&amp;rdquo;.&#xA;Hopefully this is the final rename. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Nightly OSX builds are online</title>
       <link>/blog/nightly-osx-builds-are-online/</link>
       <pubDate>Mon, 15 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/nightly-osx-builds-are-online/</guid>
       <description>Nightly builds for OSX now available here.</description>
     </item>
-    
     <item>
       <title>Released new v3.3.1 .dmg for OSX</title>
       <link>/blog/released-new-v3-3-1-dmg-for-osx/</link>
       <pubDate>Tue, 02 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/released-new-v3-3-1-dmg-for-osx/</guid>
       <description>Released a new version 3.3.1 .dmg for OSX. The previous one had an old SQLite version in it.</description>
     </item>
-    
     <item>
       <title>Version 3.3.1 released</title>
       <link>/blog/version-3-3-1-released/</link>
       <pubDate>Sun, 31 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-3-1-released/</guid>
       <description>Version 3.3.1 released, using the new name. No functional changes from 3.3.0.</description>
     </item>
-    
     <item>
       <title>Project renamed</title>
       <link>/blog/project-renamed/</link>
       <pubDate>Thu, 28 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/project-renamed/</guid>
-      <description>Project renamed to &amp;ldquo;Database Browser for SQLite&amp;rdquo;, at Richard Hipp&amp;rsquo;s request. 😄</description>
+      <description>Project renamed to &amp;ldquo;Database Browser for SQLite&amp;rdquo;, at Richard Hipp&amp;rsquo;s request. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.3.0 released</title>
       <link>/blog/version-3-3-0-released/</link>
       <pubDate>Sun, 24 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-3-0-released/</guid>
       <description>Version 3.3.0 released. Several bug fixes and improvements, a recommended upgrade.</description>
     </item>
-    
     <item>
       <title>Version 3.2.0 released</title>
       <link>/blog/version-3-2-0-released/</link>
       <pubDate>Sun, 06 Jul 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-2-0-released/</guid>
       <description>Version 3.2.0 released. Lots of improvements, a recommended upgrade.</description>
     </item>
-    
     <item>
       <title>Downloads</title>
       <link>/dl/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      
       <guid>/dl/</guid>
-      <description>(Please consider sponsoring us on Patreon 😄)
-Windows Our latest release (3.12.2) for Windows:
-DB Browser for SQLite - Standard installer for 32-bit Windows DB Browser for SQLite - .zip (no installer) for 32-bit Windows DB Browser for SQLite - Standard installer for 64-bit Windows DB Browser for SQLite - .zip (no installer) for 64-bit Windows Windows PortableApp DB Browser for SQLite - PortableApp Note - If for any reason the standard Windows release does not work (e.</description>
+      <description>(Please consider sponsoring us on Patreon &amp;#x1f604;)&#xA;Windows Our latest release (3.12.2) for Windows:&#xA;DB Browser for SQLite - Standard installer for 32-bit Windows DB Browser for SQLite - .zip (no installer) for 32-bit Windows DB Browser for SQLite - Standard installer for 64-bit Windows DB Browser for SQLite - .zip (no installer) for 64-bit Windows Windows PortableApp DB Browser for SQLite - PortableApp Note - If for any reason the standard Windows release does not work (e.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/stats/index.html
+++ b/docs/stats/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Statistics - DB Browser for SQLite</title>
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -121,9 +122,9 @@ to a newer version.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.10.x/index.html
+++ b/docs/tags/3.10.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.10.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.10.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.10.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -112,9 +111,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.10.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.10.x/index.xml
+++ b/docs/tags/3.10.x/index.xml
@@ -6,51 +6,42 @@
     <description>Recent content in 3.10.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 28 Sep 2017 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.10.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 28 Sep 2017 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.10.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp version of 3.10.1</title>
       <link>/blog/portableapp-version-of-3-10-1/</link>
       <pubDate>Thu, 28 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-10-1/</guid>
-      <description>Added PortableApp version of 3.10.1. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.10.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.10.1 released</title>
       <link>/blog/version-3-10-1-released/</link>
       <pubDate>Wed, 20 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-10-1-released/</guid>
       <description>DB Browser for SQLite 3.10.1 has been released! :D</description>
     </item>
-    
     <item>
       <title>Version 3.10.0 released</title>
       <link>/blog/version-3-10-0-released/</link>
       <pubDate>Sun, 20 Aug 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-10-0-released/</guid>
-      <description>DB Browser for SQLite 3.10.0 has been released! Yay! 😀</description>
+      <description>DB Browser for SQLite 3.10.0 has been released! Yay! &amp;#x1f600;</description>
     </item>
-    
     <item>
       <title>Second beta release for 3.10.0</title>
       <link>/blog/second-beta-release-for-3-10-0/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-for-3-10-0/</guid>
       <description>The second beta release for our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.10.0</title>
       <link>/blog/first-beta-release-of-3-10-0/</link>
       <pubDate>Fri, 21 Jul 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-10-0/</guid>
       <description>The first beta release of our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.11.x/index.html
+++ b/docs/tags/3.11.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.11.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.11.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.11.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -150,9 +149,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.11.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.11.x/index.xml
+++ b/docs/tags/3.11.x/index.xml
@@ -6,106 +6,77 @@
     <description>Recent content in 3.11.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 07 May 2019 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.11.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Tue, 07 May 2019 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.11.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp for 3.11.2 release now available</title>
       <link>/blog/portableapp-for-3-11-2-release-now-available/</link>
       <pubDate>Tue, 07 May 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-11-2-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
     </item>
-    
     <item>
       <title>Version 3.11.2 released</title>
       <link>/blog/version-3-11-2-released/</link>
       <pubDate>Thu, 04 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-2-released/</guid>
-      <description>This is a minor bug fix release in the 3.11.x series
-Bug fixes and enhancements since 3.11.1 Enable &amp;lsquo;Edit Database Cell&amp;rsquo; when view is editable (#1756) DB browser crashes when I try to attach additional database to current one (#1758) CASE-SENSITIVITY: Error importing data from SQL file: cannot start a transaction within a transaction (#1764) Cell edit window considers binary data to be text/numeric if first byte is in ascii range (#1772) Crashes when browsing a empty view with view editing enabled (#1774) Trying to save after successfull import fails (#1777) Attach encrypted database results in Out of Memory Error (#1799) File is not a database (#1814) Can&amp;rsquo;t remove password from an encrypted database any more (#1829) grammar: Fix keywords as table name and keywords as column name (1a59c8cbda47684dfc0b55283fc6fdb396adc832) Updated translation strings Korean (#1600) Brazilian Portuguese (#1830) Italian (#1833) German (e2ad5459d569801f9a635391f774e81ca1009e85) Include SQLite 3.</description>
+      <description>This is a minor bug fix release in the 3.11.x series&#xA;Bug fixes and enhancements since 3.11.1 Enable &amp;lsquo;Edit Database Cell&amp;rsquo; when view is editable (#1756) DB browser crashes when I try to attach additional database to current one (#1758) CASE-SENSITIVITY: Error importing data from SQL file: cannot start a transaction within a transaction (#1764) Cell edit window considers binary data to be text/numeric if first byte is in ascii range (#1772) Crashes when browsing a empty view with view editing enabled (#1774) Trying to save after successfull import fails (#1777) Attach encrypted database results in Out of Memory Error (#1799) File is not a database (#1814) Can&amp;rsquo;t remove password from an encrypted database any more (#1829) grammar: Fix keywords as table name and keywords as column name (1a59c8cbda47684dfc0b55283fc6fdb396adc832) Updated translation strings Korean (#1600) Brazilian Portuguese (#1830) Italian (#1833) German (e2ad5459d569801f9a635391f774e81ca1009e85) Include SQLite 3.</description>
     </item>
-    
     <item>
       <title>macOS installer rebuilt for 3.11.1</title>
       <link>/blog/macos-installer-rebuilt-for-3-11-1/</link>
       <pubDate>Sat, 23 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/macos-installer-rebuilt-for-3-11-1/</guid>
-      <description>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &amp;ldquo;light theme mode&amp;rdquo; (the Aqua look) on macOS Mojave. 😄
-https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg
-It&amp;rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&amp;rsquo;t yet properly support. Without this workaround, the colour pallete was unusable in important places. eg white on white when browsing data 😦
-Jesse Jackson, thank you so much for showing us how to fix this problem.</description>
+      <description>The macOS installer for 3.11.1 has been updated, so now when the application runs it does so in &amp;ldquo;light theme mode&amp;rdquo; (the Aqua look) on macOS Mojave. &amp;#x1f604;&#xA;https://download.sqlitebrowser.org/DB.Browser.for.SQLite-3.11.1v2.dmg&#xA;It&amp;rsquo;s a workaround for anyone using Mojave in Dark mode, which Qt doesn&amp;rsquo;t yet properly support. Without this workaround, the colour pallete was unusable in important places. eg white on white when browsing data &amp;#x1f626;&#xA;Jesse Jackson, thank you so much for showing us how to fix this problem.</description>
     </item>
-    
     <item>
       <title>Version 3.11.1 released</title>
       <link>/blog/version-3-11-1-released/</link>
       <pubDate>Mon, 18 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-1-released/</guid>
-      <description>Note that this is effectively 3.11.0 from last week, with a critical bug fix on top + some other additional fixes.
-Note 2 - If you&amp;rsquo;re using Dark Mode on macOS Mojave, Do Not download this release. Dark Mode support is broken (badly) on MacOS. It should (hopefully) be fixed in the next point release.
-Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support on Linux Dark mode support for windows and macOS isn&amp;rsquo;t working yet.</description>
+      <description>Note that this is effectively 3.11.0 from last week, with a critical bug fix on top + some other additional fixes.&#xA;Note 2 - If you&amp;rsquo;re using Dark Mode on macOS Mojave, Do Not download this release. Dark Mode support is broken (badly) on MacOS. It should (hopefully) be fixed in the next point release.&#xA;Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support on Linux Dark mode support for windows and macOS isn&amp;rsquo;t working yet.</description>
     </item>
-    
     <item>
       <title>Version 3.11.0 pulled - encrypting databases non-functional</title>
       <link>/blog/version-3-11-0-pulled/</link>
       <pubDate>Mon, 11 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-0-pulled/</guid>
-      <description>A serious bug has been found in the recent 3.11.0 release&amp;hellip; newly encrypting databases doesn&amp;rsquo;t work (#1732), instead displaying an error message. 😦
-Existing databases - encrypted or not - can be opened without problem. The problem only occurs when attempting to newly encrypt a database.
-The links on our download page have been reverted back to the prior stable release (3.10.1) for now, while we look into this.
-There will probably be a 3.</description>
+      <description>A serious bug has been found in the recent 3.11.0 release&amp;hellip; newly encrypting databases doesn&amp;rsquo;t work (#1732), instead displaying an error message. &amp;#x1f626;&#xA;Existing databases - encrypted or not - can be opened without problem. The problem only occurs when attempting to newly encrypt a database.&#xA;The links on our download page have been reverted back to the prior stable release (3.10.1) for now, while we look into this.&#xA;There will probably be a 3.</description>
     </item>
-    
     <item>
       <title>Version 3.11.0 released</title>
       <link>/blog/version-3-11-0-released/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-11-0-released/</guid>
       <description>Highlights DBHub.io improvements CSV import: speed, memory usage, usability, type detection and new default rules Attach databases Menu options for filtering JSON and XML editors Improvements to the plot UI Better copy &amp;amp; paste support Dark theme support Multi-threaded loading of data Default quotes changed to double quotes Add Record dialog Printing support The math extensions for SQLite are included in the windows and macOS installers @SilvioGrosso has kindly created a video showing how to load the math extensions on windows Downloads DB.</description>
     </item>
-    
     <item>
       <title>Third beta release of 3.11.0</title>
       <link>/blog/third-beta-release-of-3-11-0y/</link>
       <pubDate>Thu, 13 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/third-beta-release-of-3-11-0y/</guid>
       <description>The third beta builds for our next major release are ready for testing. Please try them out, and report any weirdness.</description>
     </item>
-    
     <item>
       <title>Second beta release of 3.11.0</title>
       <link>/blog/second-beta-release-of-3-11-0/</link>
       <pubDate>Wed, 12 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-of-3-11-0/</guid>
       <description>The second beta builds for our next major release are ready.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.11.0</title>
       <link>/blog/first-beta-release-of-3-11-0/</link>
       <pubDate>Tue, 27 Nov 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-11-0/</guid>
       <description>The first beta builds for our next major release are ready for testing.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.11.0</title>
       <link>/blog/first-alpha-release-for-3-11-0/</link>
       <pubDate>Wed, 10 Oct 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-11-0/</guid>
       <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.12.x/index.html
+++ b/docs/tags/3.12.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.12.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.12.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.12.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -129,9 +128,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.12.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.12.x/index.xml
+++ b/docs/tags/3.12.x/index.xml
@@ -6,79 +6,56 @@
     <description>Recent content in 3.12.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 18 May 2021 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.12.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Tue, 18 May 2021 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.12.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Version 3.12.2 released</title>
       <link>/blog/version-3-12-2-released/</link>
       <pubDate>Tue, 18 May 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-2-released/</guid>
-      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.
-You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. 😄
-The changes in this over the 3.12.1 release include:
-Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
+      <description>This is a minor maintenance release, primarily to update the internal certificates for anonymous communication with the DBHub.io servers.&#xA;You don&amp;rsquo;t need to upgrade unless you&amp;rsquo;re using DBHub.io anonymously. If you&amp;rsquo;re using DBHub.io with your own client certificate, this upgrade won&amp;rsquo;t really do much either. &amp;#x1f604;&#xA;The changes in this over the 3.12.1 release include:&#xA;Fix saving the list of extensions in the Preferences dialog (bd0e1feead6bb446f8a703338aa9893bf281e5b4) Corrected a typo in the French translation (3bbd4ee271f98301476143749f7bf4abed052efe) Updated the included SQLite and SQLCipher libraries to their latest release (SQLite 3.</description>
     </item>
-    
     <item>
       <title>Version 3.12.1 released</title>
       <link>/blog/version-3-12-1-released/</link>
       <pubDate>Mon, 09 Nov 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-1-released/</guid>
-      <description>This is the first bug fix release for our 3.12.x series.
-There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. 😄
-Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
+      <description>This is the first bug fix release for our 3.12.x series.&#xA;There aren&amp;rsquo;t any &amp;ldquo;super critical must upgrade&amp;rdquo; bugs fixed, so updating isn&amp;rsquo;t urgent. &amp;#x1f604;&#xA;Downloads DB.Browser.for.SQLite-3.12.1-win32-v2.msi - Standard (MSI) installer for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win32.zip - .zip (no installer) for Win32 and WinXP DB.Browser.for.SQLite-3.12.1-win64-v2.msi - Standard (MSI) installer for Win64 DB.Browser.for.SQLite-3.12.1-win64.zip - .zip (no installer) for Win64 DB.Browser.for.SQLite-3.12.1-v2.dmg - For macOS The changes in this over the 3.12.0 release include:</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.1</title>
       <link>/blog/first-release-candidate-for-3-12-1/</link>
       <pubDate>Sun, 27 Sep 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-1/</guid>
-      <description>This is the first, and hopefully only 😉, release candidate for DB Browser for SQLite version 3.12.1.
-Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:
-Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
+      <description>This is the first, and hopefully only &amp;#x1f609;, release candidate for DB Browser for SQLite version 3.12.1.&#xA;Downloads DB.Browser.for.SQLite-3.12.1-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.1-rc1.dmg - Standard package for macOS The changes in this over the 3.12.0 release include:&#xA;Enhancements Completely reworked interface for accessing DBHub.io Add .</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.12.0 release now available</title>
       <link>/blog/portableapp-for-3-12-0-release-now-available/</link>
       <pubDate>Thu, 18 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-12-0-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
     </item>
-    
     <item>
       <title>Version 3.12.0 released</title>
       <link>/blog/version-3-12-0-released/</link>
       <pubDate>Tue, 16 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-12-0-released/</guid>
       <description>Downloads DB.Browser.for.SQLite-3.12.0-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-win64.zip - .zip (no installer) for 64-bit Windows SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe - PortableApp for Windows DB.Browser.for.SQLite-3.12.0.dmg - Standard package for macOS Highlights Better table editing SQLite 3.25.0 added support for renaming columns with the ALTER TABLE command (previously you had to create a new table with the renamed column, copy all data over, delete the old table, then rename the new table - even leaving out some details of the process here&amp;hellip;).</description>
     </item>
-    
     <item>
       <title>First release candidate for 3.12.0</title>
       <link>/blog/first-release-candidate-for-3-12-0/</link>
       <pubDate>Mon, 08 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-candidate-for-3-12-0/</guid>
-      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.
-Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
+      <description>This is the first (and hopefully final), release candidate for DB Browser for SQLite version 3.12.0.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-rc1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-rc1.dmg - Standard package for macOS Support for pre-3.11 project file format In v3.11, the project file format was changed to support multiple sort columns (#1593), the database read-only state and the saving of configured conditional formats, while the handling of project files itself was improved too.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.12.0</title>
       <link>/blog/first-alpha-release-for-3-12-0/</link>
       <pubDate>Wed, 15 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-12-0/</guid>
-      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.
-Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
+      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.2.x/index.html
+++ b/docs/tags/3.2.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.2.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.2.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.2.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.2.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.2.x/index.xml
+++ b/docs/tags/3.2.x/index.xml
@@ -6,15 +6,14 @@
     <description>Recent content in 3.2.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 06 Jul 2014 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.2.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sun, 06 Jul 2014 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.2.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Version 3.2.0 released</title>
       <link>/blog/version-3-2-0-released/</link>
       <pubDate>Sun, 06 Jul 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-2-0-released/</guid>
       <description>Version 3.2.0 released. Lots of improvements, a recommended upgrade.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.3.x/index.html
+++ b/docs/tags/3.3.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.3.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.3.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.3.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -98,9 +97,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.3.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.3.x/index.xml
+++ b/docs/tags/3.3.x/index.xml
@@ -6,33 +6,28 @@
     <description>Recent content in 3.3.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 02 Sep 2014 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.3.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Tue, 02 Sep 2014 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.3.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Released new v3.3.1 .dmg for OSX</title>
       <link>/blog/released-new-v3-3-1-dmg-for-osx/</link>
       <pubDate>Tue, 02 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/released-new-v3-3-1-dmg-for-osx/</guid>
       <description>Released a new version 3.3.1 .dmg for OSX. The previous one had an old SQLite version in it.</description>
     </item>
-    
     <item>
       <title>Version 3.3.1 released</title>
       <link>/blog/version-3-3-1-released/</link>
       <pubDate>Sun, 31 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-3-1-released/</guid>
       <description>Version 3.3.1 released, using the new name. No functional changes from 3.3.0.</description>
     </item>
-    
     <item>
       <title>Version 3.3.0 released</title>
       <link>/blog/version-3-3-0-released/</link>
       <pubDate>Sun, 24 Aug 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-3-0-released/</guid>
       <description>Version 3.3.0 released. Several bug fixes and improvements, a recommended upgrade.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.4.x/index.html
+++ b/docs/tags/3.4.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.4.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.4.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.4.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.4.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.4.x/index.xml
+++ b/docs/tags/3.4.x/index.xml
@@ -6,24 +6,21 @@
     <description>Recent content in 3.4.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 29 Jan 2015 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.4.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 29 Jan 2015 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.4.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp version of 3.4.0</title>
       <link>/blog/portableapp-version-of-3-4-0/</link>
       <pubDate>Thu, 29 Jan 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-4-0/</guid>
       <description>Added PortableApp download for v3.4.0.</description>
     </item>
-    
     <item>
       <title>Version 3.4.0 released</title>
       <link>/blog/version-3-4-0-released/</link>
       <pubDate>Wed, 29 Oct 2014 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-4-0-released/</guid>
       <description>Version 3.4.0 released. Huge improvements in .csv handling and other tweaks.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.5.x/index.html
+++ b/docs/tags/3.5.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.5.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.5.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.5.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -98,9 +97,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.5.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.5.x/index.xml
+++ b/docs/tags/3.5.x/index.xml
@@ -6,33 +6,28 @@
     <description>Recent content in 3.5.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 17 Feb 2015 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.5.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Tue, 17 Feb 2015 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.5.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp version of 3.5.1</title>
       <link>/blog/portableapp-version-of-3-5-1/</link>
       <pubDate>Tue, 17 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-5-1/</guid>
-      <description>Added PortableApp download for v3.5.1. Thanks John. 😄</description>
+      <description>Added PortableApp download for v3.5.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.5.1 released</title>
       <link>/blog/version-3-5-1-released/</link>
       <pubDate>Sun, 08 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-5-1-released/</guid>
-      <description>Version 3.5.1 released. Fixes bugs in 3.5.0. 😄</description>
+      <description>Version 3.5.1 released. Fixes bugs in 3.5.0. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.5.0 released</title>
       <link>/blog/version-3-5-0-released/</link>
       <pubDate>Sat, 31 Jan 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-5-0-released/</guid>
       <description>Version 3.5.0 released. Adds optional SQLCipher support for MacOS X and Linux.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.6.x/index.html
+++ b/docs/tags/3.6.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.6.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.6.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.6.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -112,9 +111,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.6.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.6.x/index.xml
+++ b/docs/tags/3.6.x/index.xml
@@ -6,51 +6,42 @@
     <description>Recent content in 3.6.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sat, 09 May 2015 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.6.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sat, 09 May 2015 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.6.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp version of 3.6.0v3</title>
       <link>/blog/portableapp-version-of-3-6-0v3/</link>
       <pubDate>Sat, 09 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-6-0v3/</guid>
-      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. 😄</description>
+      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Windows XP support added back</title>
       <link>/blog/windows-xp-support-added-back/</link>
       <pubDate>Tue, 05 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/windows-xp-support-added-back/</guid>
-      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. 😉</description>
+      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. &amp;#x1f609;</description>
     </item>
-    
     <item>
       <title>Fixed windows installer for 3.6.0</title>
       <link>/blog/fixed-windows-installer-for-3-6-0/</link>
       <pubDate>Wed, 29 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/fixed-windows-installer-for-3-6-0/</guid>
       <description>The Windows installer for v3.6.0 has been fixed (was missing .dlls).</description>
     </item>
-    
     <item>
       <title>Problems with the windows installer for 3.6.0</title>
       <link>/blog/problems-with-the-windows-installer-for-3-6-0/</link>
       <pubDate>Tue, 28 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/problems-with-the-windows-installer-for-3-6-0/</guid>
       <description>Problems with the windows installer for 3.6.0. Took those down for today.</description>
     </item>
-    
     <item>
       <title>Version 3.6.0 released</title>
       <link>/blog/version-3-6-0-released/</link>
       <pubDate>Mon, 27 Apr 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-6-0-released/</guid>
       <description>Version 3.6.0 released. Lots of enhancements over all previous releases. You want this!</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.7.x/index.html
+++ b/docs/tags/3.7.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.7.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.7.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.7.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.7.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.7.x/index.xml
+++ b/docs/tags/3.7.x/index.xml
@@ -6,24 +6,21 @@
     <description>Recent content in 3.7.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 07 Jul 2015 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.7.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Tue, 07 Jul 2015 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.7.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp version of 3.7.0</title>
       <link>/blog/portableapp-version-of-3-7-0/</link>
       <pubDate>Tue, 07 Jul 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-7-0/</guid>
-      <description>Added PortableApp version of 3.7.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.7.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.7.0 released</title>
       <link>/blog/version-3-7-0-released/</link>
       <pubDate>Sun, 14 Jun 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-7-0-released/</guid>
-      <description>Version 3.7.0 released. 😄</description>
+      <description>Version 3.7.0 released. &amp;#x1f604;</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.8.x/index.html
+++ b/docs/tags/3.8.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.8.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.8.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.8.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -108,9 +107,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.8.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.8.x/index.xml
+++ b/docs/tags/3.8.x/index.xml
@@ -6,43 +6,35 @@
     <description>Recent content in 3.8.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 17 Jan 2016 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.8.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sun, 17 Jan 2016 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.8.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp version of 3.8.0</title>
       <link>/blog/portableapp-version-of-3-8-0/</link>
       <pubDate>Sun, 17 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-8-0/</guid>
-      <description>Added PortableApp version of 3.8.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.8.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>New 3.8.0 downloads for MacOS X</title>
       <link>/blog/new-3-8-0-downloads-for-macos-x/</link>
       <pubDate>Wed, 06 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-3-8-0-downloads-for-macos-x/</guid>
       <description>New 3.8.0 downloads for MacOS X today, to fix a crashing bug.</description>
     </item>
-    
     <item>
       <title>Fixed the downloads for v3.8.0</title>
       <link>/blog/fixed-the-downloads-for-v3-8-0/</link>
       <pubDate>Sat, 26 Dec 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/fixed-the-downloads-for-v3-8-0/</guid>
       <description>New (fixed) downloads for version 3.8.0 are available!</description>
     </item>
-    
     <item>
       <title>Version 3.8.0 released</title>
       <link>/blog/version-3-8-0-released/</link>
       <pubDate>Fri, 25 Dec 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-8-0-released/</guid>
-      <description>Version 3.8.0 released!
-Buggy release, removed for now. Keep using 3.7.0.</description>
+      <description>Version 3.8.0 released!&#xA;Buggy release, removed for now. Keep using 3.7.0.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/3.9.x/index.html
+++ b/docs/tags/3.9.x/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>3.9.x - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.9.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.9.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -136,9 +135,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.9.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.9.x/index.xml
+++ b/docs/tags/3.9.x/index.xml
@@ -6,79 +6,63 @@
     <description>Recent content in 3.9.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 14 May 2017 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.9.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sun, 14 May 2017 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/3.9.x/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>WinXP version for 3.9.1</title>
       <link>/blog/winxp-version-for-3-9-1/</link>
       <pubDate>Sun, 14 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/winxp-version-for-3-9-1/</guid>
       <description>Due to popular demand, there is now a Windows XP compatible download.</description>
     </item>
-    
     <item>
       <title>Rebuilt OSX binary for v3.9.1</title>
       <link>/blog/rebuilt-osx-binary-for-v3-9-1/</link>
       <pubDate>Sat, 17 Dec 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/rebuilt-osx-binary-for-v3-9-1/</guid>
       <description>The v3.9.1 binary for OSX has been rebuilt using Qt 5.7.1, to fix an important colour display problem on macOS Sierra.</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.9.1</title>
       <link>/blog/portableapp-for-3-9-1/</link>
       <pubDate>Thu, 20 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-9-1/</guid>
-      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! 😄</description>
+      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>New Qt5 based nightly builds online</title>
       <link>/blog/new-qt5-based-nightly-builds-online/</link>
       <pubDate>Mon, 17 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-qt5-based-nightly-builds-online/</guid>
       <description>New Qt5 based nightly builds are online.</description>
     </item>
-    
     <item>
       <title>Version 3.9.1 released</title>
       <link>/blog/version-3-9-1-released/</link>
       <pubDate>Mon, 03 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-1-released/</guid>
       <description>Version 3.9.1 released. Mostly bug fixes.</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.9.0</title>
       <link>/blog/portableapp-version-of-3-9-0/</link>
       <pubDate>Thu, 08 Sep 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-9-0/</guid>
-      <description>Added PortableApp download for version 3.9.0. Thanks John! 😄</description>
+      <description>Added PortableApp download for version 3.9.0. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>Version 3.9.0 released</title>
       <link>/blog/version-3-9-0-released/</link>
       <pubDate>Wed, 24 Aug 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-0-released/</guid>
       <description>The next major release, version 3.9.0 is ready for download!</description>
     </item>
-    
     <item>
       <title>Version 3.9.0 beta1 released</title>
       <link>/blog/version-3-9-0-beta1-released/</link>
       <pubDate>Sun, 14 Aug 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-0-beta1-released/</guid>
-      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.
-[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. 😄</description>
+      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.&#xA;[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. :smile:</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/alpha/index.html
+++ b/docs/tags/alpha/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>alpha - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/alpha/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/alpha/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/alpha/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/alpha/index.xml
+++ b/docs/tags/alpha/index.xml
@@ -6,25 +6,21 @@
     <description>Recent content in alpha on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Wed, 15 Apr 2020 00:00:00 +0000</lastBuildDate><atom:link href="/tags/alpha/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Wed, 15 Apr 2020 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/alpha/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>First alpha release for 3.12.0</title>
       <link>/blog/first-alpha-release-for-3-12-0/</link>
       <pubDate>Wed, 15 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-12-0/</guid>
-      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.
-Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
+      <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.&#xA;Downloads DB.Browser.for.SQLite-3.12.0-alpha1-win32.msi - Standard installer for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win32.zip - .zip (no installer) for 32-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.msi - Standard installer for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1-win64.zip - .zip (no installer) for 64-bit Windows DB.Browser.for.SQLite-3.12.0-alpha1.dmg - Standard package for macOS Note - There is no Windows XP support in the 32-bit builds at the moment.</description>
     </item>
-    
     <item>
       <title>First alpha release for 3.11.0</title>
       <link>/blog/first-alpha-release-for-3-11-0/</link>
       <pubDate>Wed, 10 Oct 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-alpha-release-for-3-11-0/</guid>
       <description>The first Windows and mac alpha builds for our next major release are ready. Please try them out, and report any weirdness.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/appimage/index.html
+++ b/docs/tags/appimage/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>AppImage - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/appimage/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/appimage/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/appimage/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/appimage/index.xml
+++ b/docs/tags/appimage/index.xml
@@ -6,24 +6,21 @@
     <description>Recent content in AppImage on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Fri, 08 Sep 2017 00:00:00 +0000</lastBuildDate><atom:link href="/tags/appimage/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Fri, 08 Sep 2017 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/appimage/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Removed continuous AppImage builds for Linux</title>
       <link>/blog/removed-continuous-appimage-builds-for-linux/</link>
       <pubDate>Fri, 08 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/removed-continuous-appimage-builds-for-linux/</guid>
       <description>Removed the continuous AppImage builds for Linux due to problems with the upload script.</description>
     </item>
-    
     <item>
       <title>AppImage builds for Linux</title>
       <link>/blog/appimage-builds-for-linux/</link>
       <pubDate>Sat, 02 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/appimage-builds-for-linux/</guid>
       <description>AppImage builds for Linux - always built from the latest DB4S commit - are now online.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/beta/index.html
+++ b/docs/tags/beta/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>beta - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/beta/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/beta/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -125,9 +124,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/beta/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/beta/index.xml
+++ b/docs/tags/beta/index.xml
@@ -6,61 +6,49 @@
     <description>Recent content in beta on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 13 Dec 2018 00:00:00 +0000</lastBuildDate><atom:link href="/tags/beta/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 13 Dec 2018 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/beta/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Third beta release of 3.11.0</title>
       <link>/blog/third-beta-release-of-3-11-0y/</link>
       <pubDate>Thu, 13 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/third-beta-release-of-3-11-0y/</guid>
       <description>The third beta builds for our next major release are ready for testing. Please try them out, and report any weirdness.</description>
     </item>
-    
     <item>
       <title>Second beta release of 3.11.0</title>
       <link>/blog/second-beta-release-of-3-11-0/</link>
       <pubDate>Wed, 12 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-of-3-11-0/</guid>
       <description>The second beta builds for our next major release are ready.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.11.0</title>
       <link>/blog/first-beta-release-of-3-11-0/</link>
       <pubDate>Tue, 27 Nov 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-11-0/</guid>
       <description>The first beta builds for our next major release are ready for testing.</description>
     </item>
-    
     <item>
       <title>Second beta release for 3.10.0</title>
       <link>/blog/second-beta-release-for-3-10-0/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/second-beta-release-for-3-10-0/</guid>
       <description>The second beta release for our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
     <item>
       <title>First beta release of 3.10.0</title>
       <link>/blog/first-beta-release-of-3-10-0/</link>
       <pubDate>Fri, 21 Jul 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-release-of-3-10-0/</guid>
       <description>The first beta release of our new 3.10.0 series is ready to download and try.</description>
     </item>
-    
     <item>
       <title>Version 3.9.0 beta1 released</title>
       <link>/blog/version-3-9-0-beta1-released/</link>
       <pubDate>Sun, 14 Aug 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/version-3-9-0-beta1-released/</guid>
-      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.
-[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. 😄</description>
+      <description>Version 3.9.0 beta1 released, with SQLCipher for strong encryption.&#xA;[Please try it out](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.9.0-beta1), and [report any new bugs](https://github.com/sqlitebrowser/sqlitebrowser/issues) you encounter. :smile:</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/compiling/index.html
+++ b/docs/tags/compiling/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>compiling - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/compiling/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/compiling/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/compiling/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/compiling/index.xml
+++ b/docs/tags/compiling/index.xml
@@ -6,15 +6,14 @@
     <description>Recent content in compiling on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 02 May 2016 00:00:00 +0000</lastBuildDate><atom:link href="/tags/compiling/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Mon, 02 May 2016 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/compiling/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Added 64-bit Windows development instructions to the wiki</title>
       <link>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</link>
       <pubDate>Mon, 02 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</guid>
       <description>Added full 64-bit Windows development instructions to the wiki, with many screenshots.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/dbhub.io/index.html
+++ b/docs/tags/dbhub.io/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>dbhub.io - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -211,9 +210,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/dbhub.io/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/dbhub.io/index.xml
+++ b/docs/tags/dbhub.io/index.xml
@@ -6,196 +6,126 @@
     <description>Recent content in dbhub.io on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate><atom:link href="/tags/dbhub.io/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/dbhub.io/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Support for SQLite extensions added</title>
       <link>/blog/support-for-sqlite-extensions-added/</link>
       <pubDate>Thu, 04 May 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/support-for-sqlite-extensions-added/</guid>
-      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:
-FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
+      <description>On DBHub.io, we&amp;rsquo;ve just rolled out support for these extensions, for all database types:&#xA;FTS3 &amp;amp; FTS3_PARENTHESIS FTS5 GEOPOLY JSON1 MATH_FUNCTIONS RTREE SOUNDEX This means your databases are now able to use all of the functions provided by these extensions, which should be very useful for a lot of people.</description>
     </item>
-    
     <item>
       <title>Live databases can be public .. and more updates</title>
       <link>/blog/live-databases-can-be-public/</link>
       <pubDate>Thu, 27 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-can-be-public/</guid>
-      <description>Another week, and another series of exciting updates to DBHub.io
-Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.
-Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.
-Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
+      <description>Another week, and another series of exciting updates to DBHub.io&#xA;Live databases can now be public The public/private setting can now be chosen when uploading a live database, and can also be changed afterwards in the Settings page for any database.&#xA;Previously, live databases were private-only as we hadn&amp;rsquo;t wired up the permissions.&#xA;Now, they can be shared with other users. By default, sharing allows for read-only access, but you can switch this to read-write access on a user-by-user basis.</description>
     </item>
-    
     <item>
       <title>Execute SQL Tab Overhaul</title>
       <link>/blog/execute-sql-tab-overhaul/</link>
       <pubDate>Wed, 26 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/execute-sql-tab-overhaul/</guid>
-      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.
-While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.
-&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;
-It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
+      <description>The &amp;lsquo;Execute SQL&amp;rsquo; tab has been overhauled.&#xA;While before it was a simple textbox and a &amp;lsquo;Run SQL&amp;rsquo; button, we&amp;rsquo;ve worked hard to improve it.&#xA;&amp;ldquo;Looks like all you&amp;rsquo;ve done is removed the button&amp;rdquo;&#xA;It&amp;rsquo;s a bit more than that. This command window not only shows the data, but also any feedback from SQLite, eg, any errors. It has syntax-highlighting support so field names are more easily identifiable compared to keywords.</description>
     </item>
-    
     <item>
       <title>Comments now enabled on blog posts</title>
       <link>/blog/comments-now-enabled-on-blog-posts/</link>
       <pubDate>Mon, 24 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/comments-now-enabled-on-blog-posts/</guid>
-      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.
-We look forward to hearing from you!</description>
+      <description>We&amp;rsquo;ve enabled comments on blog posts to further enhance discussion and the community. This is tied into Github, so you&amp;rsquo;ll need a Github account to post a comment or reply to a blog post.&#xA;We look forward to hearing from you!</description>
     </item>
-    
     <item>
       <title>More webUI related updates</title>
       <link>/blog/more-webui-related-updates/</link>
       <pubDate>Fri, 07 Apr 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/more-webui-related-updates/</guid>
-      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.
-Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data
-Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
+      <description>We&amp;rsquo;ve pushed out some more great updates on DBHub.io.&#xA;Can view live database data Can generate charts from them Can write and run SQL statements on them which change the database structure (eg CREATE/DROP TABLE), as well as data manipulation SQL (eg INSERT/UPDATE/DELETE) Can View Live Database Data&#xA;Each table in your database can be viewed, either showing every column, or just specific columns. You can create complex JOINs and view these quickly in tabular form.</description>
     </item>
-    
     <item>
       <title>Database sharing has been improved on DBHub.io</title>
       <link>/blog/database-sharing-has-been-improved-on-dbhub-io/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/database-sharing-has-been-improved-on-dbhub-io/</guid>
-      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.
-DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
+      <description>We have been hard at work making improvements to DBHub.io. We&amp;rsquo;ve not only updated database sharing, but also allowed database updates via the API. Read more about that in this blog post.&#xA;DBHub.io has allowed database sharing (databases you upload can be either private or public, with private databases shareable to specific users) since Aug 2020, but knowing what databases you&amp;rsquo;ve shared and to who has been a bit cumbersome. You&amp;rsquo;d have to remember what databases you&amp;rsquo;ve shared to then go into the settings to see who has access.</description>
     </item>
-    
     <item>
       <title>Go Library (go-dbhub) updated to work with Live databases</title>
       <link>/blog/go-library-updated-to-work-with-live-databases/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/go-library-updated-to-work-with-live-databases/</guid>
-      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.
-You can see the initial blog post for the Go library here .</description>
+      <description>Following the news that databases can now be updated via the API, we have updated the Go library which accesses and queries your databases on DBHub.io to v0.1.0 to also use these new live features. You can easily send INSERT, UPDATE or DELETE queries without sending base64 encoded SQL queries via the API.&#xA;You can see the initial blog post for the Go library here .</description>
     </item>
-    
     <item>
       <title>Live databases are now .. live!</title>
       <link>/blog/live-databases-are-now-live/</link>
       <pubDate>Sat, 25 Mar 2023 00:00:00 +0000</pubDate>
-      
       <guid>/blog/live-databases-are-now-live/</guid>
-      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.
-One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
+      <description>We&amp;rsquo;ve been working hard developing DBHub.io. One of the most requested features is the ability to perform INSERT, UPDATE and DELETE commands on a database. That now has an experimental implementation available via our API, and everyone is encouraged to try it out.&#xA;One excellent benefit of DBHub.io has always been performing queries on a SQLite database stored in the cloud. Together with creating snapshots and full version control, it has been a benefit to many users.</description>
     </item>
-    
     <item>
       <title>First release of Python library &#39;pydbhub&#39;</title>
       <link>/blog/first-release-pydbhub/</link>
       <pubDate>Sat, 05 Jun 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-release-pydbhub/</guid>
-      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. 😄
-It&amp;rsquo;s called pydbhub, and is available here:
-https://github.com/LeMoussel/pydbhub
-And on PyPi:
-https://pypi.org/project/pydbhub/</description>
+      <description>Thanks to the excellent effort of @LeMoussel, there is now a Python library for people to use and access their SQLite databases on DBHub.io. &amp;#x1f604;&#xA;It&amp;rsquo;s called pydbhub, and is available here:&#xA;https://github.com/LeMoussel/pydbhub&#xA;And on PyPi:&#xA;https://pypi.org/project/pydbhub/</description>
     </item>
-    
     <item>
       <title>New Go library for working with your DBHub.io databases</title>
       <link>/blog/new-go-library-for-working-with-your-dbhub-io-databases/</link>
       <pubDate>Sat, 01 Aug 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-go-library-for-working-with-your-dbhub-io-databases/</guid>
-      <description>For anyone with an interest in Go programming, there&amp;rsquo;s now a library to access and query your databases on DBHub.io:
-https://github.com/sqlitebrowser/go-dbhub
-Documentation is in place, code quality is good, and there are worked examples for each function call.
-It&amp;rsquo;s still in early stages of development, but seems to work well already. 😄
-What works now Run read-only queries (eg SELECT statements) on databases, returning the results as JSON List the tables, views, and indexes present in a database List the columns in a table, view or index, along with their details (Added 2020-08-02) - Generate a diff between two databases or revisions, to transform one into the other (Added 2020-08-04) - List the branches of a database (Added 2020-08-04) - Download a complete database (Added 2020-08-05) - List the databases in your account (Added 2020-08-05) - Download the database metadata (branches, releases, tags, commits, etc) Still to do Tests for each function Upload a complete database Investigate what would be needed for this to work through the Go SQL API Anything else that people suggest and seems like a good idea 😄 Requirements Go version 1.</description>
+      <description>For anyone with an interest in Go programming, there&amp;rsquo;s now a library to access and query your databases on DBHub.io:&#xA;https://github.com/sqlitebrowser/go-dbhub&#xA;Documentation is in place, code quality is good, and there are worked examples for each function call.&#xA;It&amp;rsquo;s still in early stages of development, but seems to work well already. &amp;#x1f604;&#xA;What works now Run read-only queries (eg SELECT statements) on databases, returning the results as JSON List the tables, views, and indexes present in a database List the columns in a table, view or index, along with their details (Added 2020-08-02) - Generate a diff between two databases or revisions, to transform one into the other (Added 2020-08-04) - List the branches of a database (Added 2020-08-04) - Download a complete database (Added 2020-08-05) - List the databases in your account (Added 2020-08-05) - Download the database metadata (branches, releases, tags, commits, etc) Still to do Tests for each function Upload a complete database Investigate what would be needed for this to work through the Go SQL API Anything else that people suggest and seems like a good idea &amp;#x1f604; Requirements Go version 1.</description>
     </item>
-    
     <item>
       <title>New API for remotely executing SQLite queries</title>
       <link>/blog/new-api-for-remotely-executing-sqlite-queries/</link>
       <pubDate>Sun, 19 Jul 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-api-for-remotely-executing-sqlite-queries/</guid>
-      <description>For anyone wanting to run SQL queries against their uploaded databases, there&amp;rsquo;s now an API server: https://api.dbhub.io
-As a starting point, there&amp;rsquo;s just one API call (/v1/query), and it only runs SELECT queries (eg read only database). That should be useful enough for many things though.
-Query parameters Query parameters are passed via POST only, and all results are in a fairly verbose JSON format.
-apikey - Your API key. These can be generated in your Settings page, when logged in to DBHub.</description>
+      <description>For anyone wanting to run SQL queries against their uploaded databases, there&amp;rsquo;s now an API server: https://api.dbhub.io&#xA;As a starting point, there&amp;rsquo;s just one API call (/v1/query), and it only runs SELECT queries (eg read only database). That should be useful enough for many things though.&#xA;Query parameters Query parameters are passed via POST only, and all results are in a fairly verbose JSON format.&#xA;apikey - Your API key. These can be generated in your Settings page, when logged in to DBHub.</description>
     </item>
-    
     <item>
       <title>Adding basic visualisation capability to dbhub.io</title>
       <link>/blog/adding-basic-visualisation-capability-to-dbhub-io/</link>
       <pubDate>Wed, 08 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/adding-basic-visualisation-capability-to-dbhub-io/</guid>
-      <description>We&amp;rsquo;ve begun adding the first visualisation pieces to DBHub.io, so people can display charts from their data.
-eg:
-This is only the starting point (eg a simple vertical bar chart) while we experiment, to find a good workflow that&amp;rsquo;s easy for people to use + customise.
-We&amp;rsquo;re aiming to add several more chart types to choose from, and there being a selection of easy-to-use predefined templates as well.
-Advanced users will ideally be able to input their own SQL queries for generating the data points to visualise.</description>
+      <description>We&amp;rsquo;ve begun adding the first visualisation pieces to DBHub.io, so people can display charts from their data.&#xA;eg:&#xA;This is only the starting point (eg a simple vertical bar chart) while we experiment, to find a good workflow that&amp;rsquo;s easy for people to use + customise.&#xA;We&amp;rsquo;re aiming to add several more chart types to choose from, and there being a selection of easy-to-use predefined templates as well.&#xA;Advanced users will ideally be able to input their own SQL queries for generating the data points to visualise.</description>
     </item>
-    
     <item>
       <title>New landing page for DBHub.io</title>
       <link>/blog/new-landing-page-for-dbhub-io/</link>
       <pubDate>Fri, 26 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-landing-page-for-dbhub-io/</guid>
-      <description>Our sister website, DBHub.io - where people can backup their databases, share them with others, and collaboratively develop data - has a proper landing page from today:
-https://dbhub.io
-It required quite a lot of effort to assemble, even though it&amp;rsquo;s just a simple description, screenshots (click them!), and an overview video. 😉
-Please take a look, create an account (it&amp;rsquo;s free), and try things out.
-The website code is fully Open Source, and is gaining interesting + useful capabilities over time.</description>
+      <description>Our sister website, DBHub.io - where people can backup their databases, share them with others, and collaboratively develop data - has a proper landing page from today:&#xA;https://dbhub.io&#xA;It required quite a lot of effort to assemble, even though it&amp;rsquo;s just a simple description, screenshots (click them!), and an overview video. &amp;#x1f609;&#xA;Please take a look, create an account (it&amp;rsquo;s free), and try things out.&#xA;The website code is fully Open Source, and is gaining interesting + useful capabilities over time.</description>
     </item>
-    
     <item>
       <title>Standard username/password logins now working for DBHub.io</title>
       <link>/blog/standard-username-password-logins-now-working-for-dbhub-io/</link>
       <pubDate>Wed, 10 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/standard-username-password-logins-now-working-for-dbhub-io/</guid>
-      <description>A small, but important, update about DBHub.io logins. 😉
-People can now create accounts using their own username/password again, instead of needing to login via GitHub, Google, or LinkedIn.
-It used to work (ages ago), but Auth0 found a security problem with the version of NodeJS they were using, so disabled it for everyone last year. It was fixable by changing some stuff, which has now been done.
-On a related note&amp;hellip; login (using username/password) only works if &amp;ldquo;3rd party cookies&amp;rdquo; aren&amp;rsquo;t blocked in your web browser.</description>
+      <description>A small, but important, update about DBHub.io logins. &amp;#x1f609;&#xA;People can now create accounts using their own username/password again, instead of needing to login via GitHub, Google, or LinkedIn.&#xA;It used to work (ages ago), but Auth0 found a security problem with the version of NodeJS they were using, so disabled it for everyone last year. It was fixable by changing some stuff, which has now been done.&#xA;On a related note&amp;hellip; login (using username/password) only works if &amp;ldquo;3rd party cookies&amp;rdquo; aren&amp;rsquo;t blocked in your web browser.</description>
     </item>
-    
     <item>
       <title>First (beta) DBHub.io server with DB4S integration is online</title>
       <link>/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/</link>
       <pubDate>Sat, 29 Jul 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/</guid>
-      <description>The first &amp;ldquo;db4s-beta&amp;rdquo; server is now online, which DB4S 3.10.0-beta can store/retrieve databases in.
-Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). 😄 Don&amp;rsquo;t store important data in it yet though, as we don&amp;rsquo;t have backups set up yet.</description>
+      <description>The first &amp;ldquo;db4s-beta&amp;rdquo; server is now online, which DB4S 3.10.0-beta can store/retrieve databases in.&#xA;Feel free to [create an account](https://db4s-beta.dbhub.io/justinclift/DB4S%20download%20stats.sqlite) and try things out (the link in the top right of that page). :smile: Don&amp;rsquo;t store important data in it yet though, as we don&amp;rsquo;t have backups set up yet.</description>
     </item>
-    
     <item>
       <title>Initial DBHub.io server online</title>
       <link>/blog/initial-dbhub-io-server-online/</link>
       <pubDate>Thu, 15 Dec 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/initial-dbhub-io-server-online/</guid>
-      <description>An initial DBHub.io server is online, running our latest development code. Testing and feedback is encouraged.
-Note - The data on this server will probably be wiped/reset every few days.</description>
+      <description>An initial DBHub.io server is online, running our latest development code. Testing and feedback is encouraged.&#xA;Note - The data on this server will probably be wiped/reset every few days.</description>
     </item>
-    
     <item>
       <title>New sister project: DBHub.io</title>
       <link>/blog/new-sister-project-dbhub-io/</link>
       <pubDate>Mon, 26 Sep 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-sister-project-dbhub-io/</guid>
-      <description>Added first page for our new sister project: DBHub.io. Take a look! 😄</description>
+      <description>Added first page for our new sister project: DBHub.io. Take a look! &amp;#x1f604;</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/fathom/index.html
+++ b/docs/tags/fathom/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>fathom - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/fathom/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/fathom/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/fathom/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/fathom/index.xml
+++ b/docs/tags/fathom/index.xml
@@ -6,17 +6,14 @@
     <description>Recent content in fathom on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 07 Feb 2019 00:00:00 +0000</lastBuildDate><atom:link href="/tags/fathom/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 07 Feb 2019 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/fathom/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Added public web stats using Fathom</title>
       <link>/blog/added-public-web-stats-using-fathom/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-public-web-stats-using-fathom/</guid>
-      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.
-The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.
-PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
+      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.&#xA;The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.&#xA;PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>Tags - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -269,9 +268,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -6,222 +6,175 @@
     <description>Recent content in Tags on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate><atom:link href="/tags/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 04 May 2023 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>dbhub.io</title>
       <link>/tags/dbhub.io/</link>
       <pubDate>Thu, 04 May 2023 00:00:00 +0000</pubDate>
-      
       <guid>/tags/dbhub.io/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.12.x</title>
       <link>/tags/3.12.x/</link>
       <pubDate>Tue, 18 May 2021 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.12.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>patreon</title>
       <link>/tags/patreon/</link>
       <pubDate>Sat, 06 Mar 2021 00:00:00 +0000</pubDate>
-      
       <guid>/tags/patreon/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>portableapp</title>
       <link>/tags/portableapp/</link>
       <pubDate>Thu, 18 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/tags/portableapp/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>alpha</title>
       <link>/tags/alpha/</link>
       <pubDate>Wed, 15 Apr 2020 00:00:00 +0000</pubDate>
-      
       <guid>/tags/alpha/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.11.x</title>
       <link>/tags/3.11.x/</link>
       <pubDate>Tue, 07 May 2019 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.11.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>stats</title>
       <link>/tags/stats/</link>
       <pubDate>Tue, 09 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/tags/stats/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>nightlies</title>
       <link>/tags/nightlies/</link>
       <pubDate>Sat, 02 Mar 2019 00:00:00 +0000</pubDate>
-      
       <guid>/tags/nightlies/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>fathom</title>
       <link>/tags/fathom/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/tags/fathom/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>beta</title>
       <link>/tags/beta/</link>
       <pubDate>Thu, 13 Dec 2018 00:00:00 +0000</pubDate>
-      
       <guid>/tags/beta/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>windows</title>
       <link>/tags/windows/</link>
       <pubDate>Sat, 02 Jun 2018 00:00:00 +0000</pubDate>
-      
       <guid>/tags/windows/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.10.x</title>
       <link>/tags/3.10.x/</link>
       <pubDate>Thu, 28 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.10.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>AppImage</title>
       <link>/tags/appimage/</link>
       <pubDate>Fri, 08 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/tags/appimage/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.9.x</title>
       <link>/tags/3.9.x/</link>
       <pubDate>Sun, 14 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.9.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>xp</title>
       <link>/tags/xp/</link>
       <pubDate>Sun, 14 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/tags/xp/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>compiling</title>
       <link>/tags/compiling/</link>
       <pubDate>Mon, 02 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/tags/compiling/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>msvc</title>
       <link>/tags/msvc/</link>
       <pubDate>Mon, 02 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/tags/msvc/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.8.x</title>
       <link>/tags/3.8.x/</link>
       <pubDate>Sun, 17 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.8.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.7.x</title>
       <link>/tags/3.7.x/</link>
       <pubDate>Tue, 07 Jul 2015 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.7.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.6.x</title>
       <link>/tags/3.6.x/</link>
       <pubDate>Sat, 09 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.6.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.5.x</title>
       <link>/tags/3.5.x/</link>
       <pubDate>Tue, 17 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.5.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.4.x</title>
       <link>/tags/3.4.x/</link>
       <pubDate>Thu, 29 Jan 2015 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.4.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.3.x</title>
       <link>/tags/3.3.x/</link>
       <pubDate>Tue, 02 Sep 2014 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.3.x/</guid>
       <description></description>
     </item>
-    
     <item>
       <title>3.2.x</title>
       <link>/tags/3.2.x/</link>
       <pubDate>Sun, 06 Jul 2014 00:00:00 +0000</pubDate>
-      
       <guid>/tags/3.2.x/</guid>
       <description></description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/msvc/index.html
+++ b/docs/tags/msvc/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>msvc - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/msvc/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/msvc/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/msvc/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/msvc/index.xml
+++ b/docs/tags/msvc/index.xml
@@ -6,15 +6,14 @@
     <description>Recent content in msvc on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 02 May 2016 00:00:00 +0000</lastBuildDate><atom:link href="/tags/msvc/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Mon, 02 May 2016 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/msvc/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Added 64-bit Windows development instructions to the wiki</title>
       <link>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</link>
       <pubDate>Mon, 02 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</guid>
       <description>Added full 64-bit Windows development instructions to the wiki, with many screenshots.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/nightlies/index.html
+++ b/docs/tags/nightlies/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>nightlies - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/nightlies/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/nightlies/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/nightlies/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/nightlies/index.xml
+++ b/docs/tags/nightlies/index.xml
@@ -6,21 +6,14 @@
     <description>Recent content in nightlies on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sat, 02 Mar 2019 00:00:00 +0000</lastBuildDate><atom:link href="/tags/nightlies/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sat, 02 Mar 2019 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/nightlies/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Dark theme support in our nightly builds</title>
       <link>/blog/dark-theme-support-in-our-nightly-builds/</link>
       <pubDate>Sat, 02 Mar 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/dark-theme-support-in-our-nightly-builds/</guid>
-      <description>Thanks to the dedicated efforts of @mgrojo, our nightly builds now include a &amp;ldquo;Dark style&amp;rdquo; theme courtesy of the QDarkStyleSheet project:
-To activate it, choose &amp;ldquo;Dark style&amp;rdquo; from the &amp;ldquo;Application Style&amp;rdquo; dropdown in Preferences→General:
-To turn it off, choose &amp;ldquo;Follow the desktop style&amp;rdquo; instead.
-The nightly builds for windows and macOS are here:
-https://nightlies.sqlitebrowser.org/latest/
-The nightly builds for Ubuntu Linux are here:
-https://sqlitebrowser.org/dl/#nightly-builds-1</description>
+      <description>Thanks to the dedicated efforts of @mgrojo, our nightly builds now include a &amp;ldquo;Dark style&amp;rdquo; theme courtesy of the QDarkStyleSheet project:&#xA;To activate it, choose &amp;ldquo;Dark style&amp;rdquo; from the &amp;ldquo;Application Style&amp;rdquo; dropdown in Preferences→General:&#xA;To turn it off, choose &amp;ldquo;Follow the desktop style&amp;rdquo; instead.&#xA;The nightly builds for windows and macOS are here:&#xA;https://nightlies.sqlitebrowser.org/latest/&#xA;The nightly builds for Ubuntu Linux are here:&#xA;https://sqlitebrowser.org/dl/#nightly-builds-1</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/patreon/index.html
+++ b/docs/tags/patreon/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>patreon - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/patreon/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/patreon/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/patreon/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/patreon/index.xml
+++ b/docs/tags/patreon/index.xml
@@ -6,26 +6,21 @@
     <description>Recent content in patreon on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sat, 06 Mar 2021 00:00:00 +0000</lastBuildDate><atom:link href="/tags/patreon/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sat, 06 Mar 2021 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/patreon/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Thanks to our Patreon supporters, we have a HiDPI monitor!</title>
       <link>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</link>
       <pubDate>Sat, 06 Mar 2021 00:00:00 +0000</pubDate>
-      
       <guid>/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/</guid>
-      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.
-A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.
-This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
+      <description>Thanks to our wonderful Patrons, we&amp;rsquo;ve been able to purchase a HiDPI monitor (Dell P2415Q) for Martin, one of our senior developers.&#xA;A special thanks also goes to Nikolay Zlatev of Astra Paging too, for organising the purchase and shipping of the monitor around the EU.&#xA;This should enable - or at least strongly help - with fixing the remaining HiDPI related bugs that people have reported over the years.</description>
     </item>
-    
     <item>
       <title>Patreon account created</title>
       <link>/blog/patreon-account-created/</link>
       <pubDate>Fri, 08 Jun 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/patreon-account-created/</guid>
-      <description>We&amp;rsquo;ve just created a Patreon account. Please become a Patron of DB Browser for SQLite! 😄</description>
+      <description>We&amp;rsquo;ve just created a Patreon account. Please become a Patron of DB Browser for SQLite! &amp;#x1f604;</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/portableapp/index.html
+++ b/docs/tags/portableapp/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>portableapp - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/portableapp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/portableapp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -152,9 +151,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/portableapp/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/portableapp/index.xml
+++ b/docs/tags/portableapp/index.xml
@@ -6,89 +6,70 @@
     <description>Recent content in portableapp on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Thu, 18 Jun 2020 00:00:00 +0000</lastBuildDate><atom:link href="/tags/portableapp/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Thu, 18 Jun 2020 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/portableapp/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>PortableApp for 3.12.0 release now available</title>
       <link>/blog/portableapp-for-3-12-0-release-now-available/</link>
       <pubDate>Thu, 18 Jun 2020 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-12-0-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.12.0 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.11.2 release now available</title>
       <link>/blog/portableapp-for-3-11-2-release-now-available/</link>
       <pubDate>Tue, 07 May 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-11-2-release-now-available/</guid>
-      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)
-https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
+      <description>Thanks to Chris Locke and John T. Haller, the PortableApps installer for DB Browser for SQLite 3.11.2 is now available! :)&#xA;https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.11.2_English.paf.exe</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.10.1</title>
       <link>/blog/portableapp-version-of-3-10-1/</link>
       <pubDate>Thu, 28 Sep 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-10-1/</guid>
-      <description>Added PortableApp version of 3.10.1. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.10.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp for 3.9.1</title>
       <link>/blog/portableapp-for-3-9-1/</link>
       <pubDate>Thu, 20 Oct 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-for-3-9-1/</guid>
-      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! 😄</description>
+      <description>PortableApp version of DB4S 3.9.1 now available. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.9.0</title>
       <link>/blog/portableapp-version-of-3-9-0/</link>
       <pubDate>Thu, 08 Sep 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-9-0/</guid>
-      <description>Added PortableApp download for version 3.9.0. Thanks John! 😄</description>
+      <description>Added PortableApp download for version 3.9.0. Thanks John! &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.8.0</title>
       <link>/blog/portableapp-version-of-3-8-0/</link>
       <pubDate>Sun, 17 Jan 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-8-0/</guid>
-      <description>Added PortableApp version of 3.8.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.8.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.7.0</title>
       <link>/blog/portableapp-version-of-3-7-0/</link>
       <pubDate>Tue, 07 Jul 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-7-0/</guid>
-      <description>Added PortableApp version of 3.7.0. Thanks John. 😄</description>
+      <description>Added PortableApp version of 3.7.0. Thanks John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.6.0v3</title>
       <link>/blog/portableapp-version-of-3-6-0v3/</link>
       <pubDate>Sat, 09 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-6-0v3/</guid>
-      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. 😄</description>
+      <description>Added PortableApp version of 3.6.0v3. Many thanks again John. &amp;#x1f604;</description>
     </item>
-    
     <item>
       <title>PortableApp version of 3.5.1</title>
       <link>/blog/portableapp-version-of-3-5-1/</link>
       <pubDate>Tue, 17 Feb 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/portableapp-version-of-3-5-1/</guid>
-      <description>Added PortableApp download for v3.5.1. Thanks John. 😄</description>
+      <description>Added PortableApp download for v3.5.1. Thanks John. &amp;#x1f604;</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/stats/index.html
+++ b/docs/tags/stats/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>stats - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/stats/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/stats/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/stats/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/stats/index.xml
+++ b/docs/tags/stats/index.xml
@@ -6,31 +6,21 @@
     <description>Recent content in stats on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 09 Apr 2019 00:00:00 +0000</lastBuildDate><atom:link href="/tags/stats/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Tue, 09 Apr 2019 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/stats/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>New download and daily users stats page</title>
       <link>/blog/new-download-daily-users-stats-page/</link>
       <pubDate>Tue, 09 Apr 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/new-download-daily-users-stats-page/</guid>
-      <description>Today we added a new &amp;ldquo;Stats&amp;rdquo; page, showing the number of daily downloads and daily users:
-https://sqlitebrowser.org/stats/
-The graphs are generated using Redash, and should automatically update every 10 minutes:
-https://redash.io
-Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite 😉).
-It&amp;rsquo;s running in a very low end virtual machine (eg cheap), and there&amp;rsquo;s no proper caching layer yet, so it may be a bit slow to load.</description>
+      <description>Today we added a new &amp;ldquo;Stats&amp;rdquo; page, showing the number of daily downloads and daily users:&#xA;https://sqlitebrowser.org/stats/&#xA;The graphs are generated using Redash, and should automatically update every 10 minutes:&#xA;https://redash.io&#xA;Being able to mouse over a particular day to get info for that day is useful, as is being able to download the data set (in various formats, but not yet SQLite &amp;#x1f609;).&#xA;It&amp;rsquo;s running in a very low end virtual machine (eg cheap), and there&amp;rsquo;s no proper caching layer yet, so it may be a bit slow to load.</description>
     </item>
-    
     <item>
       <title>Added public web stats using Fathom</title>
       <link>/blog/added-public-web-stats-using-fathom/</link>
       <pubDate>Thu, 07 Feb 2019 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-public-web-stats-using-fathom/</guid>
-      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.
-The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.
-PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
+      <description>Added (GDPR compliant) stats generation today for the website, using Fathom. It&amp;rsquo;s an Open Source project, written in Go, that aims to provide aggregated stats simply, without any user tracking.&#xA;The setup was fairly easy, though the ARM64 download for the current release (1.2.1) doesn&amp;rsquo;t seem to work with SQLite due to an accidental setting during their build. Hopefully fixed for the next release.&#xA;PostgreSQL is being the database, and Nginx providing HTTPS termination.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/windows/index.html
+++ b/docs/tags/windows/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>windows - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/windows/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/windows/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -104,9 +103,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/windows/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/windows/index.xml
+++ b/docs/tags/windows/index.xml
@@ -6,33 +6,28 @@
     <description>Recent content in windows on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sat, 02 Jun 2018 00:00:00 +0000</lastBuildDate><atom:link href="/tags/windows/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sat, 02 Jun 2018 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/windows/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Windows MSI installers now available</title>
       <link>/blog/windows-msi-installers-now-available/</link>
       <pubDate>Sat, 02 Jun 2018 00:00:00 +0000</pubDate>
-      
       <guid>/blog/windows-msi-installers-now-available/</guid>
       <description>Windows MSI installers are now available on our nightly build server!</description>
     </item>
-    
     <item>
       <title>WinXP version for 3.9.1</title>
       <link>/blog/winxp-version-for-3-9-1/</link>
       <pubDate>Sun, 14 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/winxp-version-for-3-9-1/</guid>
       <description>Due to popular demand, there is now a Windows XP compatible download.</description>
     </item>
-    
     <item>
       <title>Added 64-bit Windows development instructions to the wiki</title>
       <link>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</link>
       <pubDate>Mon, 02 May 2016 00:00:00 +0000</pubDate>
-      
       <guid>/blog/added-64-bit-windows-development-instructions-to-the-wiki/</guid>
       <description>Added full 64-bit Windows development instructions to the wiki, with many screenshots.</description>
     </item>
-    
   </channel>
 </rss>

--- a/docs/tags/xp/index.html
+++ b/docs/tags/xp/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Hugo 0.111.3">
+<meta name="generator" content="Hugo 0.121.1">
 
 
 <title>xp - DB Browser for SQLite</title>
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/xp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/xp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/xp/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/xp/index.xml
+++ b/docs/tags/xp/index.xml
@@ -6,24 +6,21 @@
     <description>Recent content in xp on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 14 May 2017 00:00:00 +0000</lastBuildDate><atom:link href="/tags/xp/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sun, 14 May 2017 00:00:00 +0000</lastBuildDate>
+    <atom:link href="/tags/xp/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>WinXP version for 3.9.1</title>
       <link>/blog/winxp-version-for-3-9-1/</link>
       <pubDate>Sun, 14 May 2017 00:00:00 +0000</pubDate>
-      
       <guid>/blog/winxp-version-for-3-9-1/</guid>
       <description>Due to popular demand, there is now a Windows XP compatible download.</description>
     </item>
-    
     <item>
       <title>Windows XP support added back</title>
       <link>/blog/windows-xp-support-added-back/</link>
       <pubDate>Tue, 05 May 2015 00:00:00 +0000</pubDate>
-      
       <guid>/blog/windows-xp-support-added-back/</guid>
-      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. 😉</description>
+      <description>The third version of the Windows installer for v3.6.0 has been added. This version works on XP too. &amp;#x1f609;</description>
     </item>
-    
   </channel>
 </rss>


### PR DESCRIPTION
Part 2 of 2, RSS fully qualified URL fix. This time including the exported HTML.  On the content export side, this also picked up emoji -> entity changes, and other content updates in addition to the RSS link change.

Update: emoji > entity changes may be the result of a later Hugo binary, not 100% sure, but there are also a handful of markdown changes that were exported.