### PR TITLE
Hugo 0.111.3 export site with the RSS path fix in place

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -139,9 +140,9 @@ avoid confusion with an existing application called &ldquo;Database Browser&rdqu
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/added-64-bit-windows-development-instructions-to-the-wiki/index.html
+++ b/docs/blog/added-64-bit-windows-development-instructions-to-the-wiki/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/added-public-web-stats-using-fathom/index.html
+++ b/docs/blog/added-public-web-stats-using-fathom/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -89,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/adding-basic-visualisation-capability-to-dbhub-io/index.html
+++ b/docs/blog/adding-basic-visualisation-capability-to-dbhub-io/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -95,9 +96,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/appimage-builds-for-linux/index.html
+++ b/docs/blog/appimage-builds-for-linux/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/apple-silicon-macos-package-available/index.html
+++ b/docs/blog/apple-silicon-macos-package-available/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -110,9 +111,9 @@ instructions, and all around assistance getting things working on Apple Silicon.
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/comments-now-enabled-on-blog-posts/index.html
+++ b/docs/blog/comments-now-enabled-on-blog-posts/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -87,9 +88,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/dark-theme-support-in-our-nightly-builds/index.html
+++ b/docs/blog/dark-theme-support-in-our-nightly-builds/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +95,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/database-sharing-has-been-improved-on-dbhub-io/index.html
+++ b/docs/blog/database-sharing-has-been-improved-on-dbhub-io/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -99,9 +100,9 @@ Click the blue &lsquo;Save&rsquo; button to save your changes.  You&rsquo;ll ret
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/execute-sql-tab-overhaul/index.html
+++ b/docs/blog/execute-sql-tab-overhaul/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -95,9 +96,9 @@ It has syntax-highlighting support so field names are more easily identifiable c
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-alpha-release-for-3-11-0/index.html
+++ b/docs/blog/first-alpha-release-for-3-11-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-alpha-release-for-3-12-0/index.html
+++ b/docs/blog/first-alpha-release-for-3-12-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -372,9 +373,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/index.html
+++ b/docs/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -87,9 +88,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-beta-release-of-3-10-0/index.html
+++ b/docs/blog/first-beta-release-of-3-10-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-beta-release-of-3-11-0/index.html
+++ b/docs/blog/first-beta-release-of-3-11-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-release-candidate-for-3-12-0/index.html
+++ b/docs/blog/first-release-candidate-for-3-12-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -144,9 +145,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-release-candidate-for-3-12-1/index.html
+++ b/docs/blog/first-release-candidate-for-3-12-1/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -172,9 +173,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/first-release-pydbhub/index.html
+++ b/docs/blog/first-release-pydbhub/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +92,9 @@ on DBHub.io. 😄</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/fixed-the-downloads-for-v3-8-0/index.html
+++ b/docs/blog/fixed-the-downloads-for-v3-8-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/fixed-windows-installer-for-3-6-0/index.html
+++ b/docs/blog/fixed-windows-installer-for-3-6-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/go-library-updated-to-work-with-live-databases/index.html
+++ b/docs/blog/go-library-updated-to-work-with-live-databases/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/index.html
+++ b/docs/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -88,9 +89,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/huge-thanks-to-digitalocean/index.html
+++ b/docs/blog/huge-thanks-to-digitalocean/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -92,9 +93,9 @@ is a solid choice. 😄</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/blog/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/blog/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -706,9 +705,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/blog/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/initial-dbhub-io-server-online/index.html
+++ b/docs/blog/initial-dbhub-io-server-online/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/linux-appimage-available/index.html
+++ b/docs/blog/linux-appimage-available/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -95,9 +96,9 @@ older software to use our new releases.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/live-databases-are-now-live/index.html
+++ b/docs/blog/live-databases-are-now-live/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -95,9 +96,9 @@ If you switch to <strong>Live</strong> mode, you can use <a href="https://api.db
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/live-databases-can-be-public/index.html
+++ b/docs/blog/live-databases-can-be-public/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -124,9 +125,9 @@ If you&rsquo;re using databases which hit this limit, please raise a <a href="ht
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/macos-installer-rebuilt-for-3-11-1/index.html
+++ b/docs/blog/macos-installer-rebuilt-for-3-11-1/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -88,9 +89,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/more-webui-related-updates/index.html
+++ b/docs/blog/more-webui-related-updates/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -109,9 +110,9 @@ We did say we are hard at work on the development of this.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-3-8-0-downloads-for-macos-x/index.html
+++ b/docs/blog/new-3-8-0-downloads-for-macos-x/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-api-for-remotely-executing-sqlite-queries/index.html
+++ b/docs/blog/new-api-for-remotely-executing-sqlite-queries/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -116,9 +117,9 @@ ORDER BY table1.id;
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-download-daily-users-stats-page/index.html
+++ b/docs/blog/new-download-daily-users-stats-page/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +92,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-download-servers/index.html
+++ b/docs/blog/new-download-servers/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-go-library-for-working-with-your-dbhub-io-databases/index.html
+++ b/docs/blog/new-go-library-for-working-with-your-dbhub-io-databases/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -175,9 +176,9 @@ Query results (JSON):
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-landing-page-for-dbhub-io/index.html
+++ b/docs/blog/new-landing-page-for-dbhub-io/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -89,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-qt5-based-nightly-builds-online/index.html
+++ b/docs/blog/new-qt5-based-nightly-builds-online/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-sister-project-dbhub-io/index.html
+++ b/docs/blog/new-sister-project-dbhub-io/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/new-website/index.html
+++ b/docs/blog/new-website/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +92,9 @@ likely experiment with too.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/nightly-builds-now-using-static-urls/index.html
+++ b/docs/blog/nightly-builds-now-using-static-urls/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/nightly-osx-builds-are-online/index.html
+++ b/docs/blog/nightly-osx-builds-are-online/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/patreon-account-created/index.html
+++ b/docs/blog/patreon-account-created/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-for-3-11-2-release-now-available/index.html
+++ b/docs/blog/portableapp-for-3-11-2-release-now-available/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-for-3-12-0-release-now-available/index.html
+++ b/docs/blog/portableapp-for-3-12-0-release-now-available/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-for-3-9-1/index.html
+++ b/docs/blog/portableapp-for-3-9-1/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-10-1/index.html
+++ b/docs/blog/portableapp-version-of-3-10-1/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-4-0/index.html
+++ b/docs/blog/portableapp-version-of-3-4-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-5-1/index.html
+++ b/docs/blog/portableapp-version-of-3-5-1/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-6-0v3/index.html
+++ b/docs/blog/portableapp-version-of-3-6-0v3/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-7-0/index.html
+++ b/docs/blog/portableapp-version-of-3-7-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-8-0/index.html
+++ b/docs/blog/portableapp-version-of-3-8-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/portableapp-version-of-3-9-0/index.html
+++ b/docs/blog/portableapp-version-of-3-9-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/problems-with-the-windows-installer-for-3-6-0/index.html
+++ b/docs/blog/problems-with-the-windows-installer-for-3-6-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/project-renamed-again/index.html
+++ b/docs/blog/project-renamed-again/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -87,9 +88,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/project-renamed/index.html
+++ b/docs/blog/project-renamed/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/rebuilt-osx-binary-for-v3-9-1/index.html
+++ b/docs/blog/rebuilt-osx-binary-for-v3-9-1/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/released-new-v3-3-1-dmg-for-osx/index.html
+++ b/docs/blog/released-new-v3-3-1-dmg-for-osx/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/removed-continuous-appimage-builds-for-linux/index.html
+++ b/docs/blog/removed-continuous-appimage-builds-for-linux/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/second-beta-release-for-3-10-0/index.html
+++ b/docs/blog/second-beta-release-for-3-10-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/second-beta-release-of-3-11-0/index.html
+++ b/docs/blog/second-beta-release-of-3-11-0/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/standard-username-password-logins-now-working-for-dbhub-io/index.html
+++ b/docs/blog/standard-username-password-logins-now-working-for-dbhub-io/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -89,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/support-for-sqlite-extensions-added/index.html
+++ b/docs/blog/support-for-sqlite-extensions-added/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -97,9 +98,9 @@ by these extensions, which should be very useful for a lot of people.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/test-build-with-sqlcipher-for-win64/index.html
+++ b/docs/blog/test-build-with-sqlcipher-for-win64/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/third-beta-release-of-3-11-0y/index.html
+++ b/docs/blog/third-beta-release-of-3-11-0y/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-10-0-released/index.html
+++ b/docs/blog/version-3-10-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-10-1-released/index.html
+++ b/docs/blog/version-3-10-1-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-0-pulled/index.html
+++ b/docs/blog/version-3-11-0-pulled/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -88,9 +89,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-0-released/index.html
+++ b/docs/blog/version-3-11-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -392,9 +393,9 @@ DB.Browser.for.SQLite-3.11.0-win64.zip
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-1-released/index.html
+++ b/docs/blog/version-3-11-1-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -413,9 +414,9 @@ DB.Browser.for.SQLite-3.11.1-win64.zip
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-11-2-released/index.html
+++ b/docs/blog/version-3-11-2-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -144,9 +145,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-12-0-released/index.html
+++ b/docs/blog/version-3-12-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -396,9 +397,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-12-1-released/index.html
+++ b/docs/blog/version-3-12-1-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -182,9 +183,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-12-2-released/index.html
+++ b/docs/blog/version-3-12-2-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -137,9 +138,9 @@ with your own client certificate, this upgrade won&rsquo;t really do much either
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-2-0-released/index.html
+++ b/docs/blog/version-3-2-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-3-0-released/index.html
+++ b/docs/blog/version-3-3-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-3-1-released/index.html
+++ b/docs/blog/version-3-3-1-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-4-0-released/index.html
+++ b/docs/blog/version-3-4-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-5-0-released/index.html
+++ b/docs/blog/version-3-5-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-5-1-released/index.html
+++ b/docs/blog/version-3-5-1-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-6-0-released/index.html
+++ b/docs/blog/version-3-6-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-7-0-released/index.html
+++ b/docs/blog/version-3-7-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-8-0-released/index.html
+++ b/docs/blog/version-3-8-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -86,9 +87,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-9-0-beta1-released/index.html
+++ b/docs/blog/version-3-9-0-beta1-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-9-0-released/index.html
+++ b/docs/blog/version-3-9-0-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/version-3-9-1-released/index.html
+++ b/docs/blog/version-3-9-1-released/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/windows-msi-installers-now-available/index.html
+++ b/docs/blog/windows-msi-installers-now-available/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/windows-xp-support-added-back/index.html
+++ b/docs/blog/windows-xp-support-added-back/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/blog/winxp-version-for-3-9-1/index.html
+++ b/docs/blog/winxp-version-for-3-9-1/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -85,9 +86,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/db4s/index.html
+++ b/docs/categories/db4s/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/db4s/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/db4s/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -146,9 +145,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/db4s/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/dbhub.io/index.html
+++ b/docs/categories/dbhub.io/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -143,9 +142,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/dbhub.io/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/dbhub/index.html
+++ b/docs/categories/dbhub/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/dbhub/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/dbhub/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/dbhub/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/categories/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/categories/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -104,9 +103,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/categories/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/dl/index.html
+++ b/docs/dl/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -203,9 +204,9 @@ using either this command:</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,8 +20,7 @@
 
 
 
-
-<link href="/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -750,9 +749,9 @@ in order to achieve these goals.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/stats/index.html
+++ b/docs/stats/index.html
@@ -19,6 +19,7 @@
 
 
 
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -121,9 +122,9 @@ to a newer version.</p>
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.10.x/index.html
+++ b/docs/tags/3.10.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.10.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.10.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -112,9 +111,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.10.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.11.x/index.html
+++ b/docs/tags/3.11.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.11.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.11.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -150,9 +149,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.11.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.12.x/index.html
+++ b/docs/tags/3.12.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.12.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.12.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -129,9 +128,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.12.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.2.x/index.html
+++ b/docs/tags/3.2.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.2.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.2.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.2.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.3.x/index.html
+++ b/docs/tags/3.3.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.3.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.3.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -98,9 +97,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.3.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.4.x/index.html
+++ b/docs/tags/3.4.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.4.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.4.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.4.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.5.x/index.html
+++ b/docs/tags/3.5.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.5.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.5.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -98,9 +97,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.5.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.6.x/index.html
+++ b/docs/tags/3.6.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.6.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.6.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -112,9 +111,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.6.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.7.x/index.html
+++ b/docs/tags/3.7.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.7.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.7.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.7.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.8.x/index.html
+++ b/docs/tags/3.8.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.8.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.8.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -108,9 +107,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.8.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/3.9.x/index.html
+++ b/docs/tags/3.9.x/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/3.9.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/3.9.x/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -136,9 +135,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/3.9.x/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/alpha/index.html
+++ b/docs/tags/alpha/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/alpha/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/alpha/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/alpha/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/appimage/index.html
+++ b/docs/tags/appimage/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/appimage/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/appimage/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/appimage/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/beta/index.html
+++ b/docs/tags/beta/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/beta/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/beta/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -125,9 +124,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/beta/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/compiling/index.html
+++ b/docs/tags/compiling/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/compiling/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/compiling/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/compiling/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/dbhub.io/index.html
+++ b/docs/tags/dbhub.io/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/dbhub.io/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -211,9 +210,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/dbhub.io/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/fathom/index.html
+++ b/docs/tags/fathom/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/fathom/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/fathom/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/fathom/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -269,9 +268,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/msvc/index.html
+++ b/docs/tags/msvc/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/msvc/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/msvc/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/msvc/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/nightlies/index.html
+++ b/docs/tags/nightlies/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/nightlies/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/nightlies/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -84,9 +83,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/nightlies/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/patreon/index.html
+++ b/docs/tags/patreon/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/patreon/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/patreon/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/patreon/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/portableapp/index.html
+++ b/docs/tags/portableapp/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/portableapp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/portableapp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -152,9 +151,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/portableapp/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/stats/index.html
+++ b/docs/tags/stats/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/stats/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/stats/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -91,9 +90,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/stats/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/windows/index.html
+++ b/docs/tags/windows/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/windows/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/windows/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -104,9 +103,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/windows/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>

--- a/docs/tags/xp/index.html
+++ b/docs/tags/xp/index.html
@@ -19,8 +19,7 @@
 
 
 
-
-<link href="/tags/xp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+<link href="https://sqlitebrowser.org/tags/xp/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
 
 
 
@@ -94,9 +93,9 @@
 
       <footer class="footer">
         <ul class="footer-links">
-          <li>
-            <a href="/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
-          </li>
+            <li>
+              <a href="https://sqlitebrowser.org/tags/xp/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
           <li>
             <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
           </li>


### PR DESCRIPTION
RSS fully qualified URL updates included. The former pull request used the latest Hugo (0.121.1), and ended up changing content (entity encodings) unrelated to my RSS change. This pull request matched the Hugo version used in the last run in this repo (0.111.3), and looks far more consistent. 