### PR TITLE
Fix css for /stats page

### DIFF
--- a/themes/hugo-lithium/layouts/partials/head.html
+++ b/themes/hugo-lithium/layouts/partials/head.html
@@ -31,12 +31,7 @@
 {{ partial "head_highlightjs" . }}
 <link rel="stylesheet" href="{{ "css/fonts.css" | relURL }}" media="all">
 
-{{ if ne .RelPermalink "/stats/" }}
 <link rel="stylesheet" href="{{ "css/main.css" | relURL }}" media="all">
-{{ end }}
-{{ if eq .RelPermalink "/stats/" }}
-<link rel="stylesheet" href="{{ "css/main.css" | relURL }}" media="all">
-{{ end }}
 
 {{ range .Site.Params.customCSS }}
 <link rel="stylesheet" href="{{ . | relURL }}">

--- a/themes/hugo-lithium/layouts/partials/head.html
+++ b/themes/hugo-lithium/layouts/partials/head.html
@@ -35,7 +35,7 @@
 <link rel="stylesheet" href="{{ "css/main.css" | relURL }}" media="all">
 {{ end }}
 {{ if eq .RelPermalink "/stats/" }}
-<link rel="stylesheet" href="{{ "css/mainstats.css" | relURL }}" media="all">
+<link rel="stylesheet" href="{{ "css/main.css" | relURL }}" media="all">
 {{ end }}
 
 {{ range .Site.Params.customCSS }}


### PR DESCRIPTION
The sole difference between main.css and mainstats.css was that the latter used the entire width of the browser window. All pages look fine when the content is constrained to 800px, so I simply removed references to mainstats.css in favor of main.css.