### PR TITLE
Fix css for /stats page

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/3-13-rc1-available/index.html
+++ b/docs/blog/3-13-rc1-available/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/added-64-bit-windows-development-instructions-to-the-wiki/index.html
+++ b/docs/blog/added-64-bit-windows-development-instructions-to-the-wiki/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/added-public-web-stats-using-fathom/index.html
+++ b/docs/blog/added-public-web-stats-using-fathom/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/adding-basic-visualisation-capability-to-dbhub-io/index.html
+++ b/docs/blog/adding-basic-visualisation-capability-to-dbhub-io/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/appimage-builds-for-linux/index.html
+++ b/docs/blog/appimage-builds-for-linux/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/apple-silicon-macos-package-available/index.html
+++ b/docs/blog/apple-silicon-macos-package-available/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/comments-now-enabled-on-blog-posts/index.html
+++ b/docs/blog/comments-now-enabled-on-blog-posts/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/dark-theme-support-in-our-nightly-builds/index.html
+++ b/docs/blog/dark-theme-support-in-our-nightly-builds/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/database-sharing-has-been-improved-on-dbhub-io/index.html
+++ b/docs/blog/database-sharing-has-been-improved-on-dbhub-io/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/execute-sql-tab-overhaul/index.html
+++ b/docs/blog/execute-sql-tab-overhaul/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-alpha-release-for-3-11-0/index.html
+++ b/docs/blog/first-alpha-release-for-3-11-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-alpha-release-for-3-12-0/index.html
+++ b/docs/blog/first-alpha-release-for-3-12-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/index.html
+++ b/docs/blog/first-beta-dbhub-io-server-with-db4s-integration-is-online/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-beta-release-of-3-10-0/index.html
+++ b/docs/blog/first-beta-release-of-3-10-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-beta-release-of-3-11-0/index.html
+++ b/docs/blog/first-beta-release-of-3-11-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-release-candidate-for-3-12-0/index.html
+++ b/docs/blog/first-release-candidate-for-3-12-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-release-candidate-for-3-12-1/index.html
+++ b/docs/blog/first-release-candidate-for-3-12-1/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/first-release-pydbhub/index.html
+++ b/docs/blog/first-release-pydbhub/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/fixed-the-downloads-for-v3-8-0/index.html
+++ b/docs/blog/fixed-the-downloads-for-v3-8-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/fixed-windows-installer-for-3-6-0/index.html
+++ b/docs/blog/fixed-windows-installer-for-3-6-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/go-library-updated-to-work-with-live-databases/index.html
+++ b/docs/blog/go-library-updated-to-work-with-live-databases/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/index.html
+++ b/docs/blog/hidpi-monitor-purchased-thanks-to-patreon-supporters/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/huge-thanks-to-digitalocean/index.html
+++ b/docs/blog/huge-thanks-to-digitalocean/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/initial-dbhub-io-server-online/index.html
+++ b/docs/blog/initial-dbhub-io-server-online/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/linux-appimage-available/index.html
+++ b/docs/blog/linux-appimage-available/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/live-databases-are-now-live/index.html
+++ b/docs/blog/live-databases-are-now-live/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/live-databases-can-be-public/index.html
+++ b/docs/blog/live-databases-can-be-public/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/macos-installer-rebuilt-for-3-11-1/index.html
+++ b/docs/blog/macos-installer-rebuilt-for-3-11-1/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/more-webui-related-updates/index.html
+++ b/docs/blog/more-webui-related-updates/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-3-8-0-downloads-for-macos-x/index.html
+++ b/docs/blog/new-3-8-0-downloads-for-macos-x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-api-for-remotely-executing-sqlite-queries/index.html
+++ b/docs/blog/new-api-for-remotely-executing-sqlite-queries/index.html
@@ -35,6 +35,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-download-daily-users-stats-page/index.html
+++ b/docs/blog/new-download-daily-users-stats-page/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-download-servers/index.html
+++ b/docs/blog/new-download-servers/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-go-library-for-working-with-your-dbhub-io-databases/index.html
+++ b/docs/blog/new-go-library-for-working-with-your-dbhub-io-databases/index.html
@@ -35,6 +35,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-landing-page-for-dbhub-io/index.html
+++ b/docs/blog/new-landing-page-for-dbhub-io/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-qt5-based-nightly-builds-online/index.html
+++ b/docs/blog/new-qt5-based-nightly-builds-online/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-sister-project-dbhub-io/index.html
+++ b/docs/blog/new-sister-project-dbhub-io/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/new-website/index.html
+++ b/docs/blog/new-website/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/nightly-builds-now-using-static-urls/index.html
+++ b/docs/blog/nightly-builds-now-using-static-urls/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/nightly-osx-builds-are-online/index.html
+++ b/docs/blog/nightly-osx-builds-are-online/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/patreon-account-created/index.html
+++ b/docs/blog/patreon-account-created/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-for-3-11-2-release-now-available/index.html
+++ b/docs/blog/portableapp-for-3-11-2-release-now-available/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-for-3-12-0-release-now-available/index.html
+++ b/docs/blog/portableapp-for-3-12-0-release-now-available/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-for-3-9-1/index.html
+++ b/docs/blog/portableapp-for-3-9-1/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-version-of-3-10-1/index.html
+++ b/docs/blog/portableapp-version-of-3-10-1/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-version-of-3-4-0/index.html
+++ b/docs/blog/portableapp-version-of-3-4-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-version-of-3-5-1/index.html
+++ b/docs/blog/portableapp-version-of-3-5-1/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-version-of-3-6-0v3/index.html
+++ b/docs/blog/portableapp-version-of-3-6-0v3/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-version-of-3-7-0/index.html
+++ b/docs/blog/portableapp-version-of-3-7-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-version-of-3-8-0/index.html
+++ b/docs/blog/portableapp-version-of-3-8-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/portableapp-version-of-3-9-0/index.html
+++ b/docs/blog/portableapp-version-of-3-9-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/problems-with-the-windows-installer-for-3-6-0/index.html
+++ b/docs/blog/problems-with-the-windows-installer-for-3-6-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/project-renamed-again/index.html
+++ b/docs/blog/project-renamed-again/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/project-renamed/index.html
+++ b/docs/blog/project-renamed/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/rebuilt-osx-binary-for-v3-9-1/index.html
+++ b/docs/blog/rebuilt-osx-binary-for-v3-9-1/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/released-new-v3-3-1-dmg-for-osx/index.html
+++ b/docs/blog/released-new-v3-3-1-dmg-for-osx/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/removed-continuous-appimage-builds-for-linux/index.html
+++ b/docs/blog/removed-continuous-appimage-builds-for-linux/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/second-beta-release-for-3-10-0/index.html
+++ b/docs/blog/second-beta-release-for-3-10-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/second-beta-release-of-3-11-0/index.html
+++ b/docs/blog/second-beta-release-of-3-11-0/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/signing-windows/index.html
+++ b/docs/blog/signing-windows/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/standard-username-password-logins-now-working-for-dbhub-io/index.html
+++ b/docs/blog/standard-username-password-logins-now-working-for-dbhub-io/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/support-for-sqlite-extensions-added/index.html
+++ b/docs/blog/support-for-sqlite-extensions-added/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/test-build-with-sqlcipher-for-win64/index.html
+++ b/docs/blog/test-build-with-sqlcipher-for-win64/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/third-beta-release-of-3-11-0y/index.html
+++ b/docs/blog/third-beta-release-of-3-11-0y/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-10-0-released/index.html
+++ b/docs/blog/version-3-10-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-10-1-released/index.html
+++ b/docs/blog/version-3-10-1-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-11-0-pulled/index.html
+++ b/docs/blog/version-3-11-0-pulled/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-11-0-released/index.html
+++ b/docs/blog/version-3-11-0-released/index.html
@@ -35,6 +35,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-11-1-released/index.html
+++ b/docs/blog/version-3-11-1-released/index.html
@@ -35,6 +35,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-11-2-released/index.html
+++ b/docs/blog/version-3-11-2-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-12-0-released/index.html
+++ b/docs/blog/version-3-12-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-12-1-released/index.html
+++ b/docs/blog/version-3-12-1-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-12-2-released/index.html
+++ b/docs/blog/version-3-12-2-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-2-0-released/index.html
+++ b/docs/blog/version-3-2-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-3-0-released/index.html
+++ b/docs/blog/version-3-3-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-3-1-released/index.html
+++ b/docs/blog/version-3-3-1-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-4-0-released/index.html
+++ b/docs/blog/version-3-4-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-5-0-released/index.html
+++ b/docs/blog/version-3-5-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-5-1-released/index.html
+++ b/docs/blog/version-3-5-1-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-6-0-released/index.html
+++ b/docs/blog/version-3-6-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-7-0-released/index.html
+++ b/docs/blog/version-3-7-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-8-0-released/index.html
+++ b/docs/blog/version-3-8-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-9-0-beta1-released/index.html
+++ b/docs/blog/version-3-9-0-beta1-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-9-0-released/index.html
+++ b/docs/blog/version-3-9-0-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/version-3-9-1-released/index.html
+++ b/docs/blog/version-3-9-1-released/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/windows-msi-installers-now-available/index.html
+++ b/docs/blog/windows-msi-installers-now-available/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/windows-xp-support-added-back/index.html
+++ b/docs/blog/windows-xp-support-added-back/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/blog/winxp-version-for-3-9-1/index.html
+++ b/docs/blog/winxp-version-for-3-9-1/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/categories/db4s/index.html
+++ b/docs/categories/db4s/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/categories/dbhub.io/index.html
+++ b/docs/categories/dbhub.io/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/categories/dbhub/index.html
+++ b/docs/categories/dbhub/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/categories/privacy/index.html
+++ b/docs/categories/privacy/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/css/mainstats.css
+++ b/docs/css/mainstats.css
@@ -1,0 +1,9 @@
+/* 
+CSS for /stats page 
+Override the main.css file to allow the content to fill the entire width 
+*/
+
+.content {
+  max-width: 100%;
+  margin: auto;
+}

--- a/docs/dl/index.html
+++ b/docs/dl/index.html
@@ -35,6 +35,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/privacy-policy/index.html
+++ b/docs/privacy-policy/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/stats/index.html
+++ b/docs/stats/index.html
@@ -27,6 +27,9 @@
 
 <link rel="stylesheet" href="/css/main.css" media="all">
 
+<link rel="stylesheet" href="/css/mainstats.css" media="all">
+
+
 
 
 

--- a/docs/tags/3.10.x/index.html
+++ b/docs/tags/3.10.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.11.x/index.html
+++ b/docs/tags/3.11.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.12.x/index.html
+++ b/docs/tags/3.12.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.2.x/index.html
+++ b/docs/tags/3.2.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.3.x/index.html
+++ b/docs/tags/3.3.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.4.x/index.html
+++ b/docs/tags/3.4.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.5.x/index.html
+++ b/docs/tags/3.5.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.6.x/index.html
+++ b/docs/tags/3.6.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.7.x/index.html
+++ b/docs/tags/3.7.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.8.x/index.html
+++ b/docs/tags/3.8.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/3.9.x/index.html
+++ b/docs/tags/3.9.x/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/alpha/index.html
+++ b/docs/tags/alpha/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/appimage/index.html
+++ b/docs/tags/appimage/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/beta/index.html
+++ b/docs/tags/beta/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/compiling/index.html
+++ b/docs/tags/compiling/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/dbhub.io/index.html
+++ b/docs/tags/dbhub.io/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/fathom/index.html
+++ b/docs/tags/fathom/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/msvc/index.html
+++ b/docs/tags/msvc/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/nightlies/index.html
+++ b/docs/tags/nightlies/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/patreon/index.html
+++ b/docs/tags/patreon/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/portableapp/index.html
+++ b/docs/tags/portableapp/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/stats/index.html
+++ b/docs/tags/stats/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/windows/index.html
+++ b/docs/tags/windows/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/docs/tags/xp/index.html
+++ b/docs/tags/xp/index.html
@@ -30,6 +30,7 @@
 
 
 
+
   </head>
   <body>
     <div class="wrapper">

--- a/themes/hugo-lithium/layouts/partials/head.html
+++ b/themes/hugo-lithium/layouts/partials/head.html
@@ -32,6 +32,9 @@
 <link rel="stylesheet" href="{{ "css/fonts.css" | relURL }}" media="all">
 
 <link rel="stylesheet" href="{{ "css/main.css" | relURL }}" media="all">
+{{ if eq .RelPermalink "/stats/" }}
+<link rel="stylesheet" href="{{ "css/mainstats.css" | relURL }}" media="all">
+{{ end }}
 
 {{ range .Site.Params.customCSS }}
 <link rel="stylesheet" href="{{ . | relURL }}">

--- a/themes/hugo-lithium/static/css/mainstats.css
+++ b/themes/hugo-lithium/static/css/mainstats.css
@@ -1,0 +1,9 @@
+/* 
+CSS for /stats page 
+Override the main.css file to allow the content to fill the entire width 
+*/
+
+.content {
+  max-width: 100%;
+  margin: auto;
+}


### PR DESCRIPTION
Instead of duplicating the _main.css_ file and tweaking (only) the `.content` selector, use the magic of cascading style sheets simply to override that one definition in the separate _mainstats.css_ file.

Also tweaked the _partial/head.html_ template to include _mainstats.css_ only for the /stats page.

