### PR TITLE
Main update for 3.13.1 release

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -36,13 +36,16 @@ In September 2014, the project was renamed to "DB Browser for SQLite", to
 avoid confusion with an existing application called "Database Browser".
 
 Today, the primary maintainers of DB Browser for SQLite are
-@mgrojo, @chrisjlocke, and @lucydodo,
-with major contributions from @scottfurry.
+[@mgrojo](https://github.com/mgrojo), [@lucydodo](https://github.com/lucydodo),
+[@justinclift](https://github.com/justinclift), and
+[@chrisjlocke](https://github.com/chrisjlocke), with major contributions from
+[@scottfurry](https://github.com/scottfurry).
 
 
 
 ## Release History
 
+* [Version 3.13.1 released](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.13.1) - 2024-10-16
 * [Version 3.13.0 released](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.13.0) - 2024-07-23
 * [Version 3.12.2 released](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.12.2) - 2021-05-18
 * [Version 3.12.1 released](https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.12.1) - 2020-11-09

--- a/content/blog/2024-10-16-version-3-13-1-released.md
+++ b/content/blog/2024-10-16-version-3-13-1-released.md
@@ -1,0 +1,95 @@
+---
+title: Version 3.13.1 released
+author:
+  - SeongTae Jeong
+  - Justin Clift
+date: '2024-10-16'
+slug: version-3-13-1-released
+categories:
+  - db4s
+tags:
+  - 3.13.x
+---
+
+This is a new release with several improvements to the v3.13.0 release from three months ago. :rocket:
+
+As a special mention, SQLean has a new `time` extension! Check out the following link for more information: https://github.com/nalgeon/sqlean/blob/main/docs/time.md
+
+Thanks to everyone for being part of our Community!
+
+Related Discussion: [TBD]
+
+# Downloads
+
+* [DB.Browser.for.SQLite-v3.13.1-win32.msi](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.msi) - Standard (MSI) installer for Win32
+* [DB.Browser.for.SQLite-v3.13.1-win32.zip](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.zip) - .zip (no installer) for Win32
+* [DB.Browser.for.SQLite-v3.13.1-win64.msi](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.msi) - Standard (MSI) installer for Win64
+* [DB.Browser.for.SQLite-v3.13.1-win64.zip](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.zip) - .zip (no installer) for Win64
+* [DB.Browser.for.SQLite-v3.13.1.dmg](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1.dmg) - For macOS Universal (both Apple Silicon and Intel)
+* [DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage) - AppImage for Linux
+
+# Changelog
+
+### Added
+- Add links to the wiki as help for many dialogs ([7af1256](https://github.com/sqlitebrowser/sqlitebrowser/commit/7af12565e77a5d88a0530a019aedd210763027b7), [b5abc86](https://github.com/sqlitebrowser/sqlitebrowser/commit/b5abc868aef3cc5ca908eb0af61e182205aa2291))
+
+### Changed
+- Change the default to install a shortcut to the Start menu when installing on Windows ([623bec6](https://github.com/sqlitebrowser/sqlitebrowser/commit/623bec64ce6e86f5b020b0370eeda86369d10157))
+- Improve icon image for links in 'Help' menu ([#3693](https://github.com/sqlitebrowser/sqlitebrowser/issues/3693), [027c6a8](https://github.com/sqlitebrowser/sqlitebrowser/commit/027c6a8be8238102e1c4f483615dbd749251c2b6))
+- Pragma names and values can now be translated ([#3697](https://github.com/sqlitebrowser/sqlitebrowser/pull/3697), [bf62f3a](https://github.com/sqlitebrowser/sqlitebrowser/commit/bf62f3afc4ad820c34e1be212baa6a4c24694baf), [ad00ad4](https://github.com/sqlitebrowser/sqlitebrowser/commit/ad00ad43059a28cd1a8dc81ed8c210d77b098b70))
+- Remove trailing characters when copying a single cell ([#3735](https://github.com/sqlitebrowser/sqlitebrowser/issues/3735), [20f481a](https://github.com/sqlitebrowser/sqlitebrowser/commit/20f481a1887e92ab335901adbd41fdc70274f493))
+- Update AppImage binary to use the latest SQLCipher library ([#3744](https://github.com/sqlitebrowser/sqlitebrowser/issues/3744), [21ba2d0](https://github.com/sqlitebrowser/sqlitebrowser/commit/21ba2d0eee164bfcacde884d5119650ba77ca8d7))
+- When editing the DB cells, expanded queries with parameters are included in the SQL Log ([ac3209f](https://github.com/sqlitebrowser/sqlitebrowser/commit/ac3209f9e1e0b1386cebea9ab60c71d84632f5c1))
+
+### Fixed
+-  ExtendedTableWidget
+  - Fix an issue that prevented autocomplete from working in some race conditions ([#2567](https://github.com/sqlitebrowser/sqlitebrowser/issues/2567), [#3706](https://github.com/sqlitebrowser/sqlitebrowser/issues/3706))
+  - Use Tab to close autocomplete popup and move to next item ([3aff8c9](https://github.com/sqlitebrowser/sqlitebrowser/commit/3aff8c925e0761e9f4799150d9c45b76ed0b8b19))
+  - Troubleshoot 'Copy as SQL' action on a cell results in string being copied ([#1952](https://github.com/sqlitebrowser/sqlitebrowser/issues/1952), [1ebe7bf](https://github.com/sqlitebrowser/sqlitebrowser/commit/1ebe7bf2505d91876da6f0bb29d597edc3834015))
+
+- Global
+  - Fix "Argument Missing" error in Korean translation ([#3635](https://github.com/sqlitebrowser/sqlitebrowser/issues/3635), [#3692](https://github.com/sqlitebrowser/sqlitebrowser/issues/3692), [cd518de](https://github.com/sqlitebrowser/sqlitebrowser/commit/cd518dee13e60d499d4c34b0b7b1ba1ddb52b26a))
+  - Fix an issue that caused apps to crash on some older versions of macOS ([#3691](https://github.com/sqlitebrowser/sqlitebrowser/issues/3691))
+  - Fix an issue when freezing after stopping a pragma ([#3742](https://github.com/sqlitebrowser/sqlitebrowser/pull/3742), [15a9620](https://github.com/sqlitebrowser/sqlitebrowser/commit/15a9620d11d96c62084e3702e867430bf0ec4542))
+  - Fix an issue with outputting the wrong version on macOS
+  - Troubleshooting poor HiDPI support on Windows ([#3684](https://github.com/sqlitebrowser/sqlitebrowser/issues/3684))
+  - Troubleshoot SQL queries containing VACUUM that run incorrectly ([#3723](https://github.com/sqlitebrowser/sqlitebrowser/issues/3723), [51784aa](https://github.com/sqlitebrowser/sqlitebrowser/commit/51784aa6ce697ffdd9972744ab76cb6d873592ca))
+
+- MainWindow
+  - Fix an issue when selecting queries containing multi-byte strings ([#3731](https://github.com/sqlitebrowser/sqlitebrowser/issues/3731), [f89097c](https://github.com/sqlitebrowser/sqlitebrowser/commit/f89097c25b4984052c83d852dc161628b7f48f2b))
+
+- TableBrowser
+  - Fix a bug where the first row was not adjusted ([#3767](https://github.com/sqlitebrowser/sqlitebrowser/issues/3767), [ad690e7](https://github.com/sqlitebrowser/sqlitebrowser/commit/ad690e7c2958df5e96ccb1b73f5c1076d6ec4067))
+
+- Other
+  - Fix misleading links to Qt license information ([8361aa5](https://github.com/sqlitebrowser/sqlitebrowser/commit/8361aa58298354c5829583206458e8a11090b50e))
+  - Replace 'http' with 'https' in the 'AboutDialog' and 'MainWindow' ([9832a52](https://github.com/sqlitebrowser/sqlitebrowser/commit/9832a52d95001397cc75e9780c0864672b6860c7))
+  - Translation
+    - German ([#3749](https://github.com/sqlitebrowser/sqlitebrowser/pull/3749), [8e38bf0](https://github.com/sqlitebrowser/sqlitebrowser/commit/8e38bf0b740cc560da563400e4d0a9bd1233a33c))
+    - Indonesian ([#3756](https://github.com/sqlitebrowser/sqlitebrowser/pull/3756), [6100595](https://github.com/sqlitebrowser/sqlitebrowser/commit/6100595bc7cebfc89993f72277f7bc7bba8d2d87))
+    - Japanese ([#3755](https://github.com/sqlitebrowser/sqlitebrowser/pull/3755), [e0f6aea](https://github.com/sqlitebrowser/sqlitebrowser/commit/e0f6aea00c1cf82922b7f3c7835ecfff0e7d91d5))
+    - Korean ([7bbfcf9](https://github.com/sqlitebrowser/sqlitebrowser/commit/7bbfcf97af7d4e482e47bb18f3181d3ce472acd8))
+    - Simplified Chinese ([#3761](https://github.com/sqlitebrowser/sqlitebrowser/pull/3761), [9eb0a5a](https://github.com/sqlitebrowser/sqlitebrowser/commit/9eb0a5af1fd0d27fb7d2ec6f2dfa666c4be6bdbf))
+    - Spanish ([ac33918](https://github.com/sqlitebrowser/sqlitebrowser/commit/ac3391868dad109743fc4115be31283c34fe1852))
+
+
+## Dependent library version information for each OS
+|     **-**    |                     [**Qt**](https://www.qt.io/)                     |            [**SQLCipher**](https://www.zetetic.net/sqlcipher/)            |            [**SQLite**](https://sqlite.org/)            |         [**SQLean**](https://github.com/nalgeon/sqlean)         |
+|:------------:|:--------------------------------------------------------------------:|:-------------------------------------------------------------------------:|:-------------------------------------------------------:|:---------------------------------------------------------------:|
+| **AppImage** | [5.15.13](https://www.qt.io/blog/commercial-lts-qt-5.15.13-released) | [4.5.6](https://www.zetetic.net/blog/2024/01/17/sqlcipher-4.5.6-release/) | [3.46.1](https://www.sqlite.org/releaselog/3_46_1.html) |                          Not applicable                         |
+|   **macOS**  | [5.15.13](https://www.qt.io/blog/commercial-lts-qt-5.15.13-released) | [4.6.1](https://www.zetetic.net/blog/2024/08/20/sqlcipher-4.6.1-release/) |                      Not applicable                     | [0.27.1](https://github.com/nalgeon/sqlean/releases/tag/0.27.1) |
+|  **Windows** |          [5.15.2](https://www.qt.io/blog/qt-5.15.2-released)         | [4.6.1](https://www.zetetic.net/blog/2024/08/20/sqlcipher-4.6.1-release/) | [3.46.1](https://www.sqlite.org/releaselog/3_46_1.html) | [0.27.1](https://github.com/nalgeon/sqlean/releases/tag/0.27.1) |
+
+## SHA256SUMS
+- DB.Browser.for.SQLite-v3.13.1-win32.msi
+  - e0b9f86d3da4d8d800e144295487e43de306c1bd27f14dccfe41e904736f25f7
+- DB.Browser.for.SQLite-v3.13.1-win32.zip
+  - 917ad2fa8d36e3bfa3fc85b11a34a8c18d189fbc2289f5a0d3bf41de8a288edc
+- DB.Browser.for.SQLite-v3.13.1-win64.msi
+  - d023d54b3a5db10c7e896089bb3dbe6e7f4bc4eaa9bbecb34ca414be5970f688
+- DB.Browser.for.SQLite-v3.13.1-win64.zip
+  - 22375e275ec42d96de1d3b8e9ea4ed86d2a3505c4d0ffcbd1af67aa4003e5e4d
+- DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage
+  - d6563c5c211a73192da96e3bb11a3bf83a2f3164aa4db83482c0aecf8b751b77
+- DB.Browser.for.SQLite-v3.13.1.dmg
+  - a641cfbfcc2ce609f07de44a35134dab53485ecc18e6d9afa297b514d74bd75e

--- a/content/dl.md
+++ b/content/dl.md
@@ -11,18 +11,18 @@ tags: []
 
 ## Windows
 
-Our latest release (3.13.0) for Windows:
+Our latest release (3.13.1) for Windows:
 
-* [DB Browser for SQLite - Standard installer for 32-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win32.msi)
-* [DB Browser for SQLite - .zip (no installer) for 32-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win32.zip)
-* [DB Browser for SQLite - Standard installer for 64-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win64.msi)
-* [DB Browser for SQLite - .zip (no installer) for 64-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win64.zip)
+* [DB Browser for SQLite - Standard installer for 32-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.msi)
+* [DB Browser for SQLite - .zip (no installer) for 32-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.zip)
+* [DB Browser for SQLite - Standard installer for 64-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.msi)
+* [DB Browser for SQLite - .zip (no installer) for 64-bit Windows](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.zip)
 
 *Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).*
 
 ### Windows PortableApp
 
-There is a PortableApp available, but it's still the previous (3.12.2) release version.  It should be updated to 3.13.0 over the next few days:
+There is a PortableApp available, but it's still the previous (3.12.2) release version.  It should be updated to 3.13.1 over the next few days:
 
 * [DB Browser for SQLite - PortableApp](https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.2_English.paf.exe)
 
@@ -34,9 +34,9 @@ Nightly builds often fix bugs reported after the last release. :smile:
 
 ## macOS
 
-Our latest release (3.13.0) for macOS:
+Our latest release (3.13.1) for macOS:
 
-* [DB Browser for SQLite (Universal)](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0.dmg)
+* [DB Browser for SQLite (Universal)](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1.dmg)
 
 ### Homebrew
 
@@ -56,7 +56,7 @@ Our latest release is available as an AppImage, Snap packages, and distribution 
 
 ### AppImage
 
-* [DB.Browser.for.SQLite-v3.13.0-x86.64.AppImage](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-x86.64.AppImage)
+* [DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage](https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage)
 
 Remember to change its permission bits to be executable before you run it. :smile:
 
@@ -109,7 +109,7 @@ Install the package using:
 
 #### Stable release
 
-For Ubuntu and derivaties, [@deepsidhu1313](https://github.com/deepsidhu1313)
+For Ubuntu and derivatives, [@deepsidhu1313](https://github.com/deepsidhu1313)
 provides a PPA with the latest release here:
 
 * https://launchpad.net/~linuxgndu/+archive/ubuntu/sqlitebrowser

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -95,10 +95,13 @@ support issues.</p>
 <p>In September 2014, the project was renamed to &ldquo;DB Browser for SQLite&rdquo;, to
 avoid confusion with an existing application called &ldquo;Database Browser&rdquo;.</p>
 <p>Today, the primary maintainers of DB Browser for SQLite are
-@mgrojo, @chrisjlocke, and @lucydodo,
-with major contributions from @scottfurry.</p>
+<a href="https://github.com/mgrojo">@mgrojo</a>, <a href="https://github.com/lucydodo">@lucydodo</a>,
+<a href="https://github.com/justinclift">@justinclift</a>, and
+<a href="https://github.com/chrisjlocke">@chrisjlocke</a>, with major contributions from
+<a href="https://github.com/scottfurry">@scottfurry</a>.</p>
 <h2 id="release-history">Release History</h2>
 <ul>
+<li><a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.13.1">Version 3.13.1 released</a> - 2024-10-16</li>
 <li><a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.13.0">Version 3.13.0 released</a> - 2024-07-23</li>
 <li><a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.12.2">Version 3.12.2 released</a> - 2021-05-18</li>
 <li><a href="https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.12.1">Version 3.12.1 released</a> - 2020-11-09</li>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -68,6 +68,13 @@
     <h2 class="archive-title">2024</h2>
     
     <article class="archive-item">
+      <a href="/blog/version-3-13-1-released/" class="archive-item-link">Version 3.13.1 released</a>
+      <span class="archive-item-date">
+        2024-10-16
+      </span>
+    </article>
+    
+    <article class="archive-item">
       <a href="/blog/version-3-13-1-rc2-released/" class="archive-item-link">Version 3.13.1-rc2 released</a>
       <span class="archive-item-date">
         2024-09-30

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -6,7 +6,20 @@
     <description>Recent content in Blogs on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 30 Sep 2024 00:00:00 +0000</lastBuildDate><atom:link href="/blog/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Wed, 16 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="/blog/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Version 3.13.1 released</title>
+      <link>/blog/version-3-13-1-released/</link>
+      <pubDate>Wed, 16 Oct 2024 00:00:00 +0000</pubDate>
+      
+      <guid>/blog/version-3-13-1-released/</guid>
+      <description>This is a new release with several improvements to the v3.13.0 release from three months ago. 🚀
+As a special mention, SQLean has a new time extension! Check out the following link for more information: https://github.com/nalgeon/sqlean/blob/main/docs/time.md
+Thanks to everyone for being part of our Community!
+Related Discussion: [TBD]
+Downloads DB.Browser.for.SQLite-v3.13.1-win32.msi - Standard (MSI) installer for Win32 DB.Browser.for.SQLite-v3.13.1-win32.zip - .zip (no installer) for Win32 DB.Browser.for.SQLite-v3.13.1-win64.msi - Standard (MSI) installer for Win64 DB.</description>
+    </item>
+    
     <item>
       <title>Version 3.13.1-rc2 released</title>
       <link>/blog/version-3-13-1-rc2-released/</link>

--- a/docs/blog/version-3-13-1-released/index.html
+++ b/docs/blog/version-3-13-1-released/index.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Hugo 0.111.3">
+
+
+<title>Version 3.13.1 released - DB Browser for SQLite</title>
+<meta property="og:title" content="Version 3.13.1 released - DB Browser for SQLite">
+
+
+  <link href='/favicon.ico' rel='icon' type='image/x-icon'/>
+
+
+
+  
+
+
+
+
+<link href="https://sqlitebrowser.org/index.xml" rel="alternate" type="application/rss+xml" title="DB Browser for SQLite" />
+
+
+
+<link rel="stylesheet" href="/css/fonts.css" media="all">
+
+<link rel="stylesheet" href="/css/main.css" media="all">
+
+
+
+
+
+  </head>
+  <body>
+    <div class="wrapper">
+      <header class="header">
+        <nav class="nav">
+  <a href="/" class="nav-logo">
+    <img src="/images/sqlitebrowser.svg"
+         width="50"
+         height="50"
+         alt="DB Browser for SQLite logo">
+  </a>
+  <ul class="nav-links">
+    <li><a href="/about/">About</a></li>
+    <li><a href="/dl/"><b>Download</b></a></li>
+    <li><a href="/blog/">Blog</a></li>
+    <li><a href="https://github.com/sqlitebrowser/sqlitebrowser/wiki">Docs</a></li>
+    <li><a href="https://github.com/sqlitebrowser/sqlitebrowser">GitHub</a></li>
+    <li><a href="https://gitter.im/sqlitebrowser/sqlitebrowser">Gitter</a></li>
+    <li><a href="/stats/">Stats</a></li>
+    <li><a href="https://www.patreon.com/db4s">Patreon</a></li>
+    <li><a href="https://dbhub.io">DBHub.io</a></li>
+  </ul>
+</nav>
+
+      </header>
+
+
+<main class="content" role="main">
+
+  <article class="article">
+    
+    <span class="article-duration">2 min read</span>
+    
+
+    <h1 class="article-title">Version 3.13.1 released</h1>
+
+    
+    <span class="article-date">2024-10-16</span>
+    
+
+    <div class="article-content">
+      <p>This is a new release with several improvements to the v3.13.0 release from three months ago. 🚀</p>
+<p>As a special mention, SQLean has a new <code>time</code> extension! Check out the following link for more information: <a href="https://github.com/nalgeon/sqlean/blob/main/docs/time.md">https://github.com/nalgeon/sqlean/blob/main/docs/time.md</a></p>
+<p>Thanks to everyone for being part of our Community!</p>
+<p>Related Discussion: [TBD]</p>
+<h1 id="downloads">Downloads</h1>
+<ul>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.msi">DB.Browser.for.SQLite-v3.13.1-win32.msi</a> - Standard (MSI) installer for Win32</li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.zip">DB.Browser.for.SQLite-v3.13.1-win32.zip</a> - .zip (no installer) for Win32</li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.msi">DB.Browser.for.SQLite-v3.13.1-win64.msi</a> - Standard (MSI) installer for Win64</li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.zip">DB.Browser.for.SQLite-v3.13.1-win64.zip</a> - .zip (no installer) for Win64</li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1.dmg">DB.Browser.for.SQLite-v3.13.1.dmg</a> - For macOS Universal (both Apple Silicon and Intel)</li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage">DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage</a> - AppImage for Linux</li>
+</ul>
+<h1 id="changelog">Changelog</h1>
+<h3 id="added">Added</h3>
+<ul>
+<li>Add links to the wiki as help for many dialogs (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/7af12565e77a5d88a0530a019aedd210763027b7">7af1256</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/b5abc868aef3cc5ca908eb0af61e182205aa2291">b5abc86</a>)</li>
+</ul>
+<h3 id="changed">Changed</h3>
+<ul>
+<li>Change the default to install a shortcut to the Start menu when installing on Windows (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/623bec64ce6e86f5b020b0370eeda86369d10157">623bec6</a>)</li>
+<li>Improve icon image for links in &lsquo;Help&rsquo; menu (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3693">#3693</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/027c6a8be8238102e1c4f483615dbd749251c2b6">027c6a8</a>)</li>
+<li>Pragma names and values can now be translated (<a href="https://github.com/sqlitebrowser/sqlitebrowser/pull/3697">#3697</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/bf62f3afc4ad820c34e1be212baa6a4c24694baf">bf62f3a</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/ad00ad43059a28cd1a8dc81ed8c210d77b098b70">ad00ad4</a>)</li>
+<li>Remove trailing characters when copying a single cell (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3735">#3735</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/20f481a1887e92ab335901adbd41fdc70274f493">20f481a</a>)</li>
+<li>Update AppImage binary to use the latest SQLCipher library (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3744">#3744</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/21ba2d0eee164bfcacde884d5119650ba77ca8d7">21ba2d0</a>)</li>
+<li>When editing the DB cells, expanded queries with parameters are included in the SQL Log (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/ac3209f9e1e0b1386cebea9ab60c71d84632f5c1">ac3209f</a>)</li>
+</ul>
+<h3 id="fixed">Fixed</h3>
+<ul>
+<li>
+<p>ExtendedTableWidget</p>
+</li>
+<li>
+<p>Fix an issue that prevented autocomplete from working in some race conditions (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/2567">#2567</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3706">#3706</a>)</p>
+</li>
+<li>
+<p>Use Tab to close autocomplete popup and move to next item (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/3aff8c925e0761e9f4799150d9c45b76ed0b8b19">3aff8c9</a>)</p>
+</li>
+<li>
+<p>Troubleshoot &lsquo;Copy as SQL&rsquo; action on a cell results in string being copied (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/1952">#1952</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/1ebe7bf2505d91876da6f0bb29d597edc3834015">1ebe7bf</a>)</p>
+</li>
+<li>
+<p>Global</p>
+<ul>
+<li>Fix &ldquo;Argument Missing&rdquo; error in Korean translation (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3635">#3635</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3692">#3692</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/cd518dee13e60d499d4c34b0b7b1ba1ddb52b26a">cd518de</a>)</li>
+<li>Fix an issue that caused apps to crash on some older versions of macOS (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3691">#3691</a>)</li>
+<li>Fix an issue when freezing after stopping a pragma (<a href="https://github.com/sqlitebrowser/sqlitebrowser/pull/3742">#3742</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/15a9620d11d96c62084e3702e867430bf0ec4542">15a9620</a>)</li>
+<li>Fix an issue with outputting the wrong version on macOS</li>
+<li>Troubleshooting poor HiDPI support on Windows (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3684">#3684</a>)</li>
+<li>Troubleshoot SQL queries containing VACUUM that run incorrectly (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3723">#3723</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/51784aa6ce697ffdd9972744ab76cb6d873592ca">51784aa</a>)</li>
+</ul>
+</li>
+<li>
+<p>MainWindow</p>
+<ul>
+<li>Fix an issue when selecting queries containing multi-byte strings (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3731">#3731</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/f89097c25b4984052c83d852dc161628b7f48f2b">f89097c</a>)</li>
+</ul>
+</li>
+<li>
+<p>TableBrowser</p>
+<ul>
+<li>Fix a bug where the first row was not adjusted (<a href="https://github.com/sqlitebrowser/sqlitebrowser/issues/3767">#3767</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/ad690e7c2958df5e96ccb1b73f5c1076d6ec4067">ad690e7</a>)</li>
+</ul>
+</li>
+<li>
+<p>Other</p>
+<ul>
+<li>Fix misleading links to Qt license information (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/8361aa58298354c5829583206458e8a11090b50e">8361aa5</a>)</li>
+<li>Replace &lsquo;http&rsquo; with &lsquo;https&rsquo; in the &lsquo;AboutDialog&rsquo; and &lsquo;MainWindow&rsquo; (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/9832a52d95001397cc75e9780c0864672b6860c7">9832a52</a>)</li>
+<li>Translation
+<ul>
+<li>German (<a href="https://github.com/sqlitebrowser/sqlitebrowser/pull/3749">#3749</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/8e38bf0b740cc560da563400e4d0a9bd1233a33c">8e38bf0</a>)</li>
+<li>Indonesian (<a href="https://github.com/sqlitebrowser/sqlitebrowser/pull/3756">#3756</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/6100595bc7cebfc89993f72277f7bc7bba8d2d87">6100595</a>)</li>
+<li>Japanese (<a href="https://github.com/sqlitebrowser/sqlitebrowser/pull/3755">#3755</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/e0f6aea00c1cf82922b7f3c7835ecfff0e7d91d5">e0f6aea</a>)</li>
+<li>Korean (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/7bbfcf97af7d4e482e47bb18f3181d3ce472acd8">7bbfcf9</a>)</li>
+<li>Simplified Chinese (<a href="https://github.com/sqlitebrowser/sqlitebrowser/pull/3761">#3761</a>, <a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/9eb0a5af1fd0d27fb7d2ec6f2dfa666c4be6bdbf">9eb0a5a</a>)</li>
+<li>Spanish (<a href="https://github.com/sqlitebrowser/sqlitebrowser/commit/ac3391868dad109743fc4115be31283c34fe1852">ac33918</a>)</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h2 id="dependent-library-version-information-for-each-os">Dependent library version information for each OS</h2>
+<table>
+<thead>
+<tr>
+<th style="text-align:center"><strong>-</strong></th>
+<th style="text-align:center"><a href="https://www.qt.io/"><strong>Qt</strong></a></th>
+<th style="text-align:center"><a href="https://www.zetetic.net/sqlcipher/"><strong>SQLCipher</strong></a></th>
+<th style="text-align:center"><a href="https://sqlite.org/"><strong>SQLite</strong></a></th>
+<th style="text-align:center"><a href="https://github.com/nalgeon/sqlean"><strong>SQLean</strong></a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:center"><strong>AppImage</strong></td>
+<td style="text-align:center"><a href="https://www.qt.io/blog/commercial-lts-qt-5.15.13-released">5.15.13</a></td>
+<td style="text-align:center"><a href="https://www.zetetic.net/blog/2024/01/17/sqlcipher-4.5.6-release/">4.5.6</a></td>
+<td style="text-align:center"><a href="https://www.sqlite.org/releaselog/3_46_1.html">3.46.1</a></td>
+<td style="text-align:center">Not applicable</td>
+</tr>
+<tr>
+<td style="text-align:center"><strong>macOS</strong></td>
+<td style="text-align:center"><a href="https://www.qt.io/blog/commercial-lts-qt-5.15.13-released">5.15.13</a></td>
+<td style="text-align:center"><a href="https://www.zetetic.net/blog/2024/08/20/sqlcipher-4.6.1-release/">4.6.1</a></td>
+<td style="text-align:center">Not applicable</td>
+<td style="text-align:center"><a href="https://github.com/nalgeon/sqlean/releases/tag/0.27.1">0.27.1</a></td>
+</tr>
+<tr>
+<td style="text-align:center"><strong>Windows</strong></td>
+<td style="text-align:center"><a href="https://www.qt.io/blog/qt-5.15.2-released">5.15.2</a></td>
+<td style="text-align:center"><a href="https://www.zetetic.net/blog/2024/08/20/sqlcipher-4.6.1-release/">4.6.1</a></td>
+<td style="text-align:center"><a href="https://www.sqlite.org/releaselog/3_46_1.html">3.46.1</a></td>
+<td style="text-align:center"><a href="https://github.com/nalgeon/sqlean/releases/tag/0.27.1">0.27.1</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="sha256sums">SHA256SUMS</h2>
+<ul>
+<li>DB.Browser.for.SQLite-v3.13.1-win32.msi
+<ul>
+<li>e0b9f86d3da4d8d800e144295487e43de306c1bd27f14dccfe41e904736f25f7</li>
+</ul>
+</li>
+<li>DB.Browser.for.SQLite-v3.13.1-win32.zip
+<ul>
+<li>917ad2fa8d36e3bfa3fc85b11a34a8c18d189fbc2289f5a0d3bf41de8a288edc</li>
+</ul>
+</li>
+<li>DB.Browser.for.SQLite-v3.13.1-win64.msi
+<ul>
+<li>d023d54b3a5db10c7e896089bb3dbe6e7f4bc4eaa9bbecb34ca414be5970f688</li>
+</ul>
+</li>
+<li>DB.Browser.for.SQLite-v3.13.1-win64.zip
+<ul>
+<li>22375e275ec42d96de1d3b8e9ea4ed86d2a3505c4d0ffcbd1af67aa4003e5e4d</li>
+</ul>
+</li>
+<li>DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage
+<ul>
+<li>d6563c5c211a73192da96e3bb11a3bf83a2f3164aa4db83482c0aecf8b751b77</li>
+</ul>
+</li>
+<li>DB.Browser.for.SQLite-v3.13.1.dmg
+<ul>
+<li>a641cfbfcc2ce609f07de44a35134dab53485ecc18e6d9afa297b514d74bd75e</li>
+</ul>
+</li>
+</ul>
+
+    </div>
+  </article>
+
+  
+
+
+</main>
+
+      <footer class="footer">
+        <ul class="footer-links">
+            <li>
+              <a href="https://sqlitebrowser.org/index.xml" type="application/rss+xml" target="_blank">RSS feed</a>
+            </li>
+          <li>
+            <a href="https://twitter.com/sqlitebrowser" target="_blank">Twitter</a>
+          </li>
+          <li>
+            <a href="/privacy-policy">Privacy policy</a>
+          </li>
+        </ul>
+        <br />
+      </footer>
+    </div>
+    
+
+    
+
+    
+<script>
+(function(f, a, t, h, o, m){
+	a[h]=a[h]||function(){
+		(a[h].q=a[h].q||[]).push(arguments)
+	};
+	o=f.createElement('script'),
+	m=f.getElementsByTagName('script')[0];
+	o.async=1; o.src=t; o.id='fathom-script';
+	m.parentNode.insertBefore(o,m)
+})(document, window, '//stats.sqlitebrowser.org/tracker.js', 'fathom');
+fathom('set', 'siteId', 'DWUMT');
+fathom('trackPageview');
+</script>
+
+
+    
+    
+  <script src="https://utteranc.es/client.js"
+        repo="sqlitebrowser/website"
+        issue-term="pathname"
+        label="utterances"
+        theme="github-light"
+        crossorigin="anonymous"
+        async>
+</script>
+    
+    
+  </body>
+</html>
+

--- a/docs/categories/db4s/index.html
+++ b/docs/categories/db4s/index.html
@@ -68,6 +68,13 @@
     <h2 class="archive-title">2024</h2>
     
     <article class="archive-item">
+      <a href="/blog/version-3-13-1-released/" class="archive-item-link">Version 3.13.1 released</a>
+      <span class="archive-item-date">
+        2024-10-16
+      </span>
+    </article>
+    
+    <article class="archive-item">
       <a href="/blog/version-3-13-1-rc2-released/" class="archive-item-link">Version 3.13.1-rc2 released</a>
       <span class="archive-item-date">
         2024-09-30

--- a/docs/categories/db4s/index.xml
+++ b/docs/categories/db4s/index.xml
@@ -6,7 +6,20 @@
     <description>Recent content in db4s on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 30 Sep 2024 00:00:00 +0000</lastBuildDate><atom:link href="/categories/db4s/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Wed, 16 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="/categories/db4s/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Version 3.13.1 released</title>
+      <link>/blog/version-3-13-1-released/</link>
+      <pubDate>Wed, 16 Oct 2024 00:00:00 +0000</pubDate>
+      
+      <guid>/blog/version-3-13-1-released/</guid>
+      <description>This is a new release with several improvements to the v3.13.0 release from three months ago. 🚀
+As a special mention, SQLean has a new time extension! Check out the following link for more information: https://github.com/nalgeon/sqlean/blob/main/docs/time.md
+Thanks to everyone for being part of our Community!
+Related Discussion: [TBD]
+Downloads DB.Browser.for.SQLite-v3.13.1-win32.msi - Standard (MSI) installer for Win32 DB.Browser.for.SQLite-v3.13.1-win32.zip - .zip (no installer) for Win32 DB.Browser.for.SQLite-v3.13.1-win64.msi - Standard (MSI) installer for Win64 DB.</description>
+    </item>
+    
     <item>
       <title>Version 3.13.1-rc2 released</title>
       <link>/blog/version-3-13-1-rc2-released/</link>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -70,7 +70,7 @@
     <article class="archive-item">
       <a href="/categories/db4s/" class="archive-item-link">db4s</a>
       <span class="archive-item-date">
-        2024-09-30
+        2024-10-16
       </span>
     </article>
     

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -6,11 +6,11 @@
     <description>Recent content in Categories on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 30 Sep 2024 00:00:00 +0000</lastBuildDate><atom:link href="/categories/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Wed, 16 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="/categories/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>db4s</title>
       <link>/categories/db4s/</link>
-      <pubDate>Mon, 30 Sep 2024 00:00:00 +0000</pubDate>
+      <pubDate>Wed, 16 Oct 2024 00:00:00 +0000</pubDate>
       
       <guid>/categories/db4s/</guid>
       <description></description>

--- a/docs/dl/index.html
+++ b/docs/dl/index.html
@@ -75,16 +75,16 @@
     <div class="article-content">
       <p>(<a href="https://www.patreon.com/db4s"><strong>Please</strong> consider sponsoring us on Patreon</a> 😄)</p>
 <h2 id="windows">Windows</h2>
-<p>Our latest release (3.13.0) for Windows:</p>
+<p>Our latest release (3.13.1) for Windows:</p>
 <ul>
-<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win32.msi">DB Browser for SQLite - Standard installer for 32-bit Windows</a></li>
-<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win32.zip">DB Browser for SQLite - .zip (no installer) for 32-bit Windows</a></li>
-<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win64.msi">DB Browser for SQLite - Standard installer for 64-bit Windows</a></li>
-<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-win64.zip">DB Browser for SQLite - .zip (no installer) for 64-bit Windows</a></li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.msi">DB Browser for SQLite - Standard installer for 32-bit Windows</a></li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win32.zip">DB Browser for SQLite - .zip (no installer) for 32-bit Windows</a></li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.msi">DB Browser for SQLite - Standard installer for 64-bit Windows</a></li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-win64.zip">DB Browser for SQLite - .zip (no installer) for 64-bit Windows</a></li>
 </ul>
 <p><em>Free code signing provided by <a href="https://signpath.io/">SignPath.io</a>, certificate by <a href="https://signpath.org/">SignPath Foundation</a>.</em></p>
 <h3 id="windows-portableapp">Windows PortableApp</h3>
-<p>There is a PortableApp available, but it&rsquo;s still the previous (3.12.2) release version.  It should be updated to 3.13.0 over the next few days:</p>
+<p>There is a PortableApp available, but it&rsquo;s still the previous (3.12.2) release version.  It should be updated to 3.13.1 over the next few days:</p>
 <ul>
 <li><a href="https://download.sqlitebrowser.org/SQLiteDatabaseBrowserPortable_3.12.2_English.paf.exe">DB Browser for SQLite - PortableApp</a></li>
 </ul>
@@ -92,9 +92,9 @@
 (e.g. gives an error), try a nightly build (<a href="#nightly-builds">below</a>).</p>
 <p>Nightly builds often fix bugs reported after the last release. 😄</p>
 <h2 id="macos">macOS</h2>
-<p>Our latest release (3.13.0) for macOS:</p>
+<p>Our latest release (3.13.1) for macOS:</p>
 <ul>
-<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0.dmg">DB Browser for SQLite (Universal)</a></li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1.dmg">DB Browser for SQLite (Universal)</a></li>
 </ul>
 <h3 id="homebrew">Homebrew</h3>
 <p>If you prefer using <a href="https://brew.sh/">Homebrew</a> for macOS, our latest release can be installed via:</p>
@@ -109,7 +109,7 @@
 <p>Our latest release is available as an AppImage, Snap packages, and distribution specific packages:</p>
 <h3 id="appimage">AppImage</h3>
 <ul>
-<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.0-x86.64.AppImage">DB.Browser.for.SQLite-v3.13.0-x86.64.AppImage</a></li>
+<li><a href="https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage">DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage</a></li>
 </ul>
 <p>Remember to change its permission bits to be executable before you run it. 😄</p>
 <h3 id="snap-packages">Snap packages</h3>
@@ -143,7 +143,7 @@
 </code></pre>
 <h3 id="ubuntu-and-derivatives">Ubuntu and Derivatives</h3>
 <h4 id="stable-release">Stable release</h4>
-<p>For Ubuntu and derivaties, <a href="https://github.com/deepsidhu1313">@deepsidhu1313</a>
+<p>For Ubuntu and derivatives, <a href="https://github.com/deepsidhu1313">@deepsidhu1313</a>
 provides a PPA with the latest release here:</p>
 <ul>
 <li><a href="https://launchpad.net/~linuxgndu/+archive/ubuntu/sqlitebrowser">https://launchpad.net/~linuxgndu/+archive/ubuntu/sqlitebrowser</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,6 +121,13 @@ Controls and wizards are available to:</p>
     <h2 class="archive-title">2024</h2>
     
     <article class="archive-item">
+      <a href="/blog/version-3-13-1-released/" class="archive-item-link">Version 3.13.1 released</a>
+      <span class="archive-item-date">
+        2024-10-16
+      </span>
+    </article>
+    
+    <article class="archive-item">
       <a href="/blog/version-3-13-1-rc2-released/" class="archive-item-link">Version 3.13.1-rc2 released</a>
       <span class="archive-item-date">
         2024-09-30

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -6,7 +6,20 @@
     <description>Recent content on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 30 Sep 2024 00:00:00 +0000</lastBuildDate><atom:link href="/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Wed, 16 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Version 3.13.1 released</title>
+      <link>/blog/version-3-13-1-released/</link>
+      <pubDate>Wed, 16 Oct 2024 00:00:00 +0000</pubDate>
+      
+      <guid>/blog/version-3-13-1-released/</guid>
+      <description>This is a new release with several improvements to the v3.13.0 release from three months ago. 🚀
+As a special mention, SQLean has a new time extension! Check out the following link for more information: https://github.com/nalgeon/sqlean/blob/main/docs/time.md
+Thanks to everyone for being part of our Community!
+Related Discussion: [TBD]
+Downloads DB.Browser.for.SQLite-v3.13.1-win32.msi - Standard (MSI) installer for Win32 DB.Browser.for.SQLite-v3.13.1-win32.zip - .zip (no installer) for Win32 DB.Browser.for.SQLite-v3.13.1-win64.msi - Standard (MSI) installer for Win64 DB.</description>
+    </item>
+    
     <item>
       <title>Version 3.13.1-rc2 released</title>
       <link>/blog/version-3-13-1-rc2-released/</link>
@@ -959,7 +972,7 @@ Hopefully this is the final rename. 😄</description>
       
       <guid>/dl/</guid>
       <description>(Please consider sponsoring us on Patreon 😄)
-Windows Our latest release (3.13.0) for Windows:
+Windows Our latest release (3.13.1) for Windows:
 DB Browser for SQLite - Standard installer for 32-bit Windows DB Browser for SQLite - .zip (no installer) for 32-bit Windows DB Browser for SQLite - Standard installer for 64-bit Windows DB Browser for SQLite - .zip (no installer) for 64-bit Windows Free code signing provided by SignPath.io, certificate by SignPath Foundation.
 Windows PortableApp There is a PortableApp available, but it&amp;rsquo;s still the previous (3.</description>
     </item>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,22 +3,25 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>/tags/3.13.x/</loc>
-    <lastmod>2024-09-30T00:00:00+00:00</lastmod>
+    <lastmod>2024-10-16T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/blog/</loc>
-    <lastmod>2024-09-30T00:00:00+00:00</lastmod>
+    <lastmod>2024-10-16T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/categories/</loc>
-    <lastmod>2024-09-30T00:00:00+00:00</lastmod>
+    <lastmod>2024-10-16T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/</loc>
-    <lastmod>2024-09-30T00:00:00+00:00</lastmod>
+    <lastmod>2024-10-16T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/categories/db4s/</loc>
-    <lastmod>2024-09-30T00:00:00+00:00</lastmod>
+    <lastmod>2024-10-16T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/tags/</loc>
-    <lastmod>2024-09-30T00:00:00+00:00</lastmod>
+    <lastmod>2024-10-16T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>/blog/version-3-13-1-released/</loc>
+    <lastmod>2024-10-16T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/blog/version-3-13-1-rc2-released/</loc>
     <lastmod>2024-09-30T00:00:00+00:00</lastmod>

--- a/docs/tags/3.13.x/index.html
+++ b/docs/tags/3.13.x/index.html
@@ -68,6 +68,13 @@
     <h2 class="archive-title">2024</h2>
     
     <article class="archive-item">
+      <a href="/blog/version-3-13-1-released/" class="archive-item-link">Version 3.13.1 released</a>
+      <span class="archive-item-date">
+        2024-10-16
+      </span>
+    </article>
+    
+    <article class="archive-item">
       <a href="/blog/version-3-13-1-rc2-released/" class="archive-item-link">Version 3.13.1-rc2 released</a>
       <span class="archive-item-date">
         2024-09-30

--- a/docs/tags/3.13.x/index.xml
+++ b/docs/tags/3.13.x/index.xml
@@ -6,7 +6,20 @@
     <description>Recent content in 3.13.x on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 30 Sep 2024 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.13.x/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Wed, 16 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="/tags/3.13.x/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Version 3.13.1 released</title>
+      <link>/blog/version-3-13-1-released/</link>
+      <pubDate>Wed, 16 Oct 2024 00:00:00 +0000</pubDate>
+      
+      <guid>/blog/version-3-13-1-released/</guid>
+      <description>This is a new release with several improvements to the v3.13.0 release from three months ago. 🚀
+As a special mention, SQLean has a new time extension! Check out the following link for more information: https://github.com/nalgeon/sqlean/blob/main/docs/time.md
+Thanks to everyone for being part of our Community!
+Related Discussion: [TBD]
+Downloads DB.Browser.for.SQLite-v3.13.1-win32.msi - Standard (MSI) installer for Win32 DB.Browser.for.SQLite-v3.13.1-win32.zip - .zip (no installer) for Win32 DB.Browser.for.SQLite-v3.13.1-win64.msi - Standard (MSI) installer for Win64 DB.</description>
+    </item>
+    
     <item>
       <title>Version 3.13.1-rc2 released</title>
       <link>/blog/version-3-13-1-rc2-released/</link>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -70,7 +70,7 @@
     <article class="archive-item">
       <a href="/tags/3.13.x/" class="archive-item-link">3.13.x</a>
       <span class="archive-item-date">
-        2024-09-30
+        2024-10-16
       </span>
     </article>
     

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -6,11 +6,11 @@
     <description>Recent content in Tags on DB Browser for SQLite</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Mon, 30 Sep 2024 00:00:00 +0000</lastBuildDate><atom:link href="/tags/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Wed, 16 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="/tags/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>3.13.x</title>
       <link>/tags/3.13.x/</link>
-      <pubDate>Mon, 30 Sep 2024 00:00:00 +0000</pubDate>
+      <pubDate>Wed, 16 Oct 2024 00:00:00 +0000</pubDate>
       
       <guid>/tags/3.13.x/</guid>
       <description></description>


### PR DESCRIPTION
This should be the vast majority of the changes needed for the 3.13.1 release.

We need to wait for the 3.13.1 release to be available on the DB4S download server, and for the GitHub release to be public.

The `TBD` discussion link will need updating with the url GitHub creates for the release too. :smile: